### PR TITLE
Call Yarn Command From the Corepack Command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,4 +95,4 @@ jobs:
         uses: ./yarn-install-action
 
       - name: Build Package
-        run: yarn pack
+        run: corepack yarn pack

--- a/main/index.mjs
+++ b/main/index.mjs
@@ -1334,7 +1334,7 @@ var exec = __nccwpck_require__(926);
  * Install dependencies using Yarn.
  */
 async function install() {
-    await exec.exec("yarn", ["install"]);
+    await exec.exec("corepack", ["yarn", "install"]);
 }
 
 ;// CONCATENATED MODULE: ./dist/main.mjs

--- a/src/yarn.mts
+++ b/src/yarn.mts
@@ -4,5 +4,5 @@ import exec from "@actions/exec";
  * Install dependencies using Yarn.
  */
 export async function install(): Promise<void> {
-  await exec.exec("yarn", ["install"]);
+  await exec.exec("corepack", ["yarn", "install"]);
 }

--- a/src/yarn.test.js
+++ b/src/yarn.test.js
@@ -5,11 +5,10 @@ jest.unstable_mockModule("@actions/exec", () => ({
   default: {
     ...jest.requireActual("@actions/exec"),
     exec: async (commandLine, args) => {
-      if (commandLine != "yarn" || args.length < 1) return;
-      switch (args[0]) {
-        case "install":
-          installed = true;
-          break;
+      if (commandLine == "corepack" && args.length > 0) {
+        if (args[0] == "yarn" && args.length > 1) {
+          if (args[1] == "install") installed = true;
+        }
       }
     },
   },


### PR DESCRIPTION
This pull request modifies Yarn to be called from the Corepack using the `corepack yarn ...` command. It fixes #12.