### PR TITLE
Enable Yarn with Corepack Prior to Dependency Installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,9 +88,6 @@ jobs:
             action.yaml
             main
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
       - name: Install Dependencies
         uses: ./yarn-install-action
 

--- a/main/index.mjs
+++ b/main/index.mjs
@@ -1334,6 +1334,7 @@ var exec = __nccwpck_require__(926);
  * Install dependencies using Yarn.
  */
 async function install() {
+    await exec.exec("corepack", ["enable", "yarn"]);
     await exec.exec("corepack", ["yarn", "install"]);
 }
 

--- a/src/yarn.mts
+++ b/src/yarn.mts
@@ -4,5 +4,6 @@ import exec from "@actions/exec";
  * Install dependencies using Yarn.
  */
 export async function install(): Promise<void> {
+  await exec.exec("corepack", ["enable", "yarn"]);
   await exec.exec("corepack", ["yarn", "install"]);
 }

--- a/src/yarn.test.js
+++ b/src/yarn.test.js
@@ -5,10 +5,10 @@ jest.unstable_mockModule("@actions/exec", () => ({
   default: {
     ...jest.requireActual("@actions/exec"),
     exec: async (commandLine, args) => {
-      if (commandLine == "corepack" && args.length > 0) {
-        if (args[0] == "yarn" && args.length > 1) {
-          if (args[1] == "install") installed = true;
-        }
+      switch ([commandLine, ...args].join(" ")) {
+        case "corepack yarn install":
+          installed = true;
+          break;
       }
     },
   },

--- a/src/yarn.test.js
+++ b/src/yarn.test.js
@@ -1,12 +1,19 @@
 import { jest } from "@jest/globals";
 
+let enabled = false;
 let installed = false;
+
 jest.unstable_mockModule("@actions/exec", () => ({
   default: {
     ...jest.requireActual("@actions/exec"),
     exec: async (commandLine, args) => {
       switch ([commandLine, ...args].join(" ")) {
+        case "corepack enable yarn":
+          enabled = true;
+          break;
+
         case "corepack yarn install":
+          if (!enabled) throw new Error("Yarn is not enabled");
           installed = true;
           break;
       }
@@ -16,6 +23,7 @@ jest.unstable_mockModule("@actions/exec", () => ({
 
 describe("install dependencies", () => {
   beforeEach(() => {
+    enabled = false;
     installed = false;
   });
 


### PR DESCRIPTION
This pull request modifies the following stuffs:
- Call `corepack enable yarn` before installing dependencies in the `install` function.
- Modify `@actions/exec` module mocking in the `yarn.test.js` to support testing if Yarn is enabled via Corepack.
- Remove step for enabling yarn in the `test-action` job in the `test.yaml` workflow.

It closes #13.