### PR TITLE
Fix Distribution Directory Rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "root": true,
+  "ignorePatterns": ["dist"],
   "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-dist/index.mjs -diff linguist-generated
+dist/** -diff linguist-generated
 yarn.lock -diff linguist-generated

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
           path: yarn-install-action
           sparse-checkout: |
             action.yaml
-            dist/index.mjs
+            dist
 
       - name: Install Dependencies
         uses: ./yarn-install-action


### PR DESCRIPTION
This pull request addresses rules related to the `dist` directory with the following changes:

- Excludes the `dist` directory from ESLint checks.
- Specifies Git attributes for the entire `dist` directory, not just the `dist/index.mjs` file.
- Utilizes sparse checkout for the entire `dist` directory in the `test-action` job of the `test` workflow, instead of only considering the `dist/index.mjs` file.