### PR TITLE
Fix Sparse Checkout for Action in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,7 @@ jobs:
           sparse-checkout: |
             action.yaml
             dist
+          sparse-checkout-cone-mode: false
 
       - name: Install Dependencies
         uses: ./yarn-install-action


### PR DESCRIPTION
This pull request resolves the sparse checkout issue by disabling cone mode during checkout. The current bug involves the sparse checkout of the action including all files in the root directory due to the default behavior of cone mode. The fix ensures that the sparse checkout behaves as intended.