### PR TITLE
Skip Cache When Lock File is Not Found

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,31 @@ jobs:
 
       - name: Build Package
         run: corepack yarn pack
+
+  test-action-without-lock-file:
+    name: Test Action Without Lock File
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: threeal/nodejs-starter
+          sparse-checkout: |
+            /**/*
+            !yarn.lock
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.1
+        with:
+          path: yarn-install-action
+          sparse-checkout: |
+            action.yaml
+            dist
+          sparse-checkout-cone-mode: false
+
+      - name: Install Dependencies
+        uses: ./yarn-install-action
+
+      - name: Build Package
+        run: corepack yarn pack

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81504,11 +81504,13 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 /* harmony import */ var _actions_cache__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(5756);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(2340);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(4926);
-/* harmony import */ var hasha__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(6242);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(2037);
-/* harmony import */ var process__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(7282);
-var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([hasha__WEBPACK_IMPORTED_MODULE_5__]);
-hasha__WEBPACK_IMPORTED_MODULE_5__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
+/* harmony import */ var hasha__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(6242);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(7147);
+/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(2037);
+/* harmony import */ var process__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(7282);
+var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([hasha__WEBPACK_IMPORTED_MODULE_6__]);
+hasha__WEBPACK_IMPORTED_MODULE_6__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
+
 
 
 
@@ -81520,21 +81522,17 @@ async function main() {
         return _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec("corepack", ["enable", "yarn"]);
     });
     const lockFileHash = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Calculating lock file hash", async () => {
-        try {
-            const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_5__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Hash: ${hash}`);
-            return hash;
-        }
-        catch (err) {
-            const errMsg = err instanceof Error ? err.message : "unknown error";
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning(`Unable to calculate lock file hash: ${errMsg}`);
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning(`Skipping cache`);
+        if (!fs__WEBPACK_IMPORTED_MODULE_3__.existsSync("yarn.lock")) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning(`Lock file not found, skipping cache`);
             return undefined;
         }
+        const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_6__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Hash: ${hash}`);
+        return hash;
     });
     const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
     const cacheKey = lockFileHash !== undefined
-        ? `yarn-install-action-${os__WEBPACK_IMPORTED_MODULE_3__.type()}-${lockFileHash}`
+        ? `yarn-install-action-${os__WEBPACK_IMPORTED_MODULE_4__.type()}-${lockFileHash}`
         : undefined;
     if (cacheKey !== undefined) {
         const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {
@@ -81560,12 +81558,14 @@ async function main() {
         ]);
     });
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
-        const env = process__WEBPACK_IMPORTED_MODULE_4__.env;
+        const env = process__WEBPACK_IMPORTED_MODULE_5__.env;
         // Prevent `yarn install` from outputting group log messages.
         env["GITHUB_ACTIONS"] = "";
         env["FORCE_COLOR"] = "true";
         // Prevent no lock file causing errors.
-        env["CI"] = "";
+        if (lockFileHash === undefined) {
+            env["CI"] = "";
+        }
         return _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec("corepack", ["yarn", "install"], { env });
     });
     if (cacheKey !== undefined) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81560,10 +81560,12 @@ async function main() {
         ]);
     });
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
-        // Prevent `yarn install` from outputting group log messages.
         const env = process__WEBPACK_IMPORTED_MODULE_4__.env;
+        // Prevent `yarn install` from outputting group log messages.
         env["GITHUB_ACTIONS"] = "";
         env["FORCE_COLOR"] = "true";
+        // Prevent no lock file causing errors.
+        env["CI"] = "";
         return _actions_exec__WEBPACK_IMPORTED_MODULE_2__.exec("corepack", ["yarn", "install"], { env });
     });
     if (cacheKey !== undefined) {

--- a/src/index.mts
+++ b/src/index.mts
@@ -59,10 +59,14 @@ async function main() {
   });
 
   await core.group("Installing dependencies", async () => {
-    // Prevent `yarn install` from outputting group log messages.
     const env = process.env as { [key: string]: string };
+
+    // Prevent `yarn install` from outputting group log messages.
     env["GITHUB_ACTIONS"] = "";
     env["FORCE_COLOR"] = "true";
+
+    // Prevent no lock file causing errors.
+    env["CI"] = "";
 
     return exec.exec("corepack", ["yarn", "install"], { env });
   });

--- a/src/index.mts
+++ b/src/index.mts
@@ -13,27 +13,39 @@ async function main() {
   const lockFileHash = await core.group(
     "Calculating lock file hash",
     async () => {
-      const hash = await hashFile("yarn.lock", { algorithm: "md5" });
-      core.info(`Hash: ${hash}`);
-      return hash;
+      try {
+        const hash = await hashFile("yarn.lock", { algorithm: "md5" });
+        core.info(`Hash: ${hash}`);
+        return hash;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : "unknown error";
+        core.warning(`Unable to calculate lock file hash: ${errMsg}`);
+        core.warning(`Skipping cache`);
+        return undefined;
+      }
     },
   );
 
   const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
-  const cacheKey = `yarn-install-action-${os.type()}-${lockFileHash}`;
+  const cacheKey =
+    lockFileHash !== undefined
+      ? `yarn-install-action-${os.type()}-${lockFileHash}`
+      : undefined;
 
-  const cacheFound = await core.group("Restoring cache", async () => {
-    const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
-    if (cacheId === undefined) {
-      core.warning("Cache not found");
-      return false;
+  if (cacheKey !== undefined) {
+    const cacheFound = await core.group("Restoring cache", async () => {
+      const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
+      if (cacheId === undefined) {
+        core.warning("Cache not found");
+        return false;
+      }
+      return true;
+    });
+
+    if (cacheFound) {
+      core.info("Cache restored successfully");
+      return;
     }
-    return true;
-  });
-
-  if (cacheFound) {
-    core.info("Cache restored successfully");
-    return;
   }
 
   await core.group("Disabling global cache", async () => {
@@ -55,9 +67,11 @@ async function main() {
     return exec.exec("corepack", ["yarn", "install"], { env });
   });
 
-  await core.group("Saving cache", async () => {
-    return cache.saveCache(cachePaths.slice(), cacheKey);
-  });
+  if (cacheKey !== undefined) {
+    await core.group("Saving cache", async () => {
+      return cache.saveCache(cachePaths.slice(), cacheKey);
+    });
+  }
 }
 
 main().catch((err) => core.setFailed(err));


### PR DESCRIPTION
This pull request introduces the following changes:
- Add`test-action-without-lock-file` job in the `test` workflow to test a case if `yarn.lock` is not available.
- Check if `yarn.lock` file exists before calculating the hash. If the file does not exist, skip cache.
- Disable `CI` env when installing dependencies if `yarn.lock` file does not exist to prevent error because of Yarn behavior on CI that will exit immediately if `yarn.lock` is modified/created.

It closes #29.