### PR TITLE
Utilize This Action Itself for Installing Node.js Dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,17 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@main
 
       - name: Build Package
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,22 +17,13 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@main
 
       - name: Check Yarn Version
         run: |
           corepack yarn set version stable
           git diff --exit-code --text HEAD
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install Dependencies
-        run: corepack yarn install
 
       - name: Check Format
         run: |


### PR DESCRIPTION
This pull request replaces steps in the `build-package` and `check-package` jobs for installing Node.js dependencies with this action itself. It closes #34.