### PR TITLE
Call Yarn Command From Corepack Command in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,9 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Dependencies
-        run: yarn install
+        run: corepack yarn install
 
       - name: Build Package
-        run: yarn build && git diff --exit-code --text HEAD
+        run: |
+          corepack yarn build
+          git diff --exit-code --text HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,9 @@ jobs:
         run: corepack enable yarn
 
       - name: Check Yarn Version
-        run: yarn set version stable && git diff --exit-code --text HEAD
+        run: |
+          corepack yarn set version stable
+          git diff --exit-code --text HEAD
 
       - name: Cache Dependencies
         uses: actions/cache@v3.3.2
@@ -30,13 +32,15 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Dependencies
-        run: yarn install
+        run: corepack yarn install
 
       - name: Check Format
-        run: yarn format && git diff --exit-code --text HEAD
+        run: |
+          corepack yarn format
+          git diff --exit-code --text HEAD
 
       - name: Check Lint
-        run: yarn lint
+        run: corepack yarn lint
 
   test-action:
     name: Test Action


### PR DESCRIPTION
This pull request modifies the `yarn` command to be called with `corepack yarn` instead in the workflows. It closes #36.