### PR TITLE
Fix ESLint Not Linting Source Files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,16 @@
   "extends": ["eslint:recommended"],
   "overrides": [
     {
+      "files": ["**/*.mjs"],
+      "parserOptions": {
+        "ecmaVersion": "2023",
+        "sourceType": "module"
+      },
+      "env": {
+        "node": true
+      }
+    },
+    {
       "files": ["package.json"],
       "plugins": ["json-files"],
       "rules": {


### PR DESCRIPTION
This pull request resolves #118 by adding a configuration in the `.eslintrc.json` file to lint the `.mjs` source files.