### PR TITLE
Set `NODE_OPTIONS` for Running `test` Script

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Test Package
         run: corepack yarn test
-        env:
-          NODE_OPTIONS: --experimental-vm-modules
 
   test-action:
     name: Test Action

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "ncc build src/index.mjs",
     "format": "prettier --write --cache . !dist",
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules yarn jest"
   },
   "dependencies": {
     "@actions/cache": "^3.2.4",
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,7 +1746,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.1"
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 10c0/f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4005,6 +4017,7 @@ __metadata:
     "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
     "@vercel/ncc": "npm:^0.38.1"
+    cross-env: "npm:^7.0.3"
     eslint: "npm:^8.56.0"
     hasha: "npm:^6.0.0"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #125 by introducing the following changes:
- Adds [cross-env](https://www.npmjs.com/package/cross-env) to the development dependencies.
- Sets the `NODE_OPTIONS` environment variable with `--experimental-vm-modules` before executing the `jest` command in the `test` script.
- Removes the `NODE_OPTIONS` environment variable from the `test-package` job in the `test` workflow.