### PR TITLE
Add Support to Global Cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,35 @@ jobs:
       - name: Build Package
         run: corepack yarn pack
 
+  test-action-with-yarn-local-cache:
+    name: Test Action With Yarn Local Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: threeal/nodejs-starter
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.1
+        with:
+          path: yarn-install-action
+          sparse-checkout: |
+            action.yaml
+            dist
+          sparse-checkout-cone-mode: false
+
+      - name: Disable Yarn Global Cache
+        run: |
+          corepack enable yarn
+          corepack yarn config set enableGlobalCache false
+
+      - name: Install Dependencies
+        uses: ./yarn-install-action
+
+      - name: Build Package
+        run: corepack yarn pack
+
   test-action-without-lock-file:
     name: Test Action Without Lock File
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -79593,15 +79593,6 @@ __webpack_async_result__();
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
 
-async function disableGlobalCache() {
-    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", [
-        "yarn",
-        "config",
-        "set",
-        "enableGlobalCache",
-        "false",
-    ]);
-}
 async function enable() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
 }
@@ -79627,7 +79618,7 @@ async function version() {
     });
     return res.stdout.trim();
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ disableGlobalCache, enable, getConfig, install, version });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ enable, getConfig, install, version });
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -79568,9 +79568,6 @@ async function main() {
             return;
         }
     }
-    await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Disabling global cache", async () => {
-        return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].disableGlobalCache */ .Z.disableGlobalCache();
-    });
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
         return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].install */ .Z.install();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,6 @@ async function main(): Promise<void> {
     }
   }
 
-  await core.group("Disabling global cache", async () => {
-    return yarn.disableGlobalCache();
-  });
-
   await core.group("Installing dependencies", async () => {
     return yarn.install();
   });

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -15,22 +15,6 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-it("should disable Yarn global cache", async () => {
-  const { exec } = await import("@actions/exec");
-  const yarn = (await import("./yarn.js")).default;
-
-  await yarn.disableGlobalCache();
-
-  expect(exec).toHaveBeenCalledTimes(1);
-  expect(exec).toHaveBeenCalledWith("corepack", [
-    "yarn",
-    "config",
-    "set",
-    "enableGlobalCache",
-    "false",
-  ]);
-});
-
 it("should enable Yarn", async () => {
   const yarn = (await import("./yarn.js")).default;
 

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,15 +1,5 @@
 import { exec, getExecOutput } from "@actions/exec";
 
-async function disableGlobalCache(): Promise<void> {
-  await exec("corepack", [
-    "yarn",
-    "config",
-    "set",
-    "enableGlobalCache",
-    "false",
-  ]);
-}
-
 async function enable(): Promise<void> {
   await exec("corepack", ["enable", "yarn"]);
 }
@@ -46,4 +36,4 @@ async function version() {
   return res.stdout.trim();
 }
 
-export default { disableGlobalCache, enable, getConfig, install, version };
+export default { enable, getConfig, install, version };


### PR DESCRIPTION
This pull request resolves #142 by introducing the following changes:
- Removes the step for disabling Yarn global cache in the `main` function.
- Adds a `test-action-with-yarn-local-cache` function in the `test` workflow.
- Removes the unused `yarn.disableGlobalCache` function.