### PR TITLE
Separate Step for Getting Cache Key and Paths

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79503,26 +79503,36 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
     const version = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].version */ .Z.version();
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Yarn version: ${version}`);
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
     if (!node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file not found, skipping cache`);
         return undefined;
     }
     const lockFileHash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Lock file hash: ${lockFileHash}`);
     const cacheKey = `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}-${lockFileHash}`;
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache key: ${cacheKey}`);
     return cacheKey;
 }
 async function getCachePaths() {
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn cache folder...");
+    const yarnCacheFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("cacheFolder");
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn deferred version folder...");
+    const yarnDefferedVersionFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder");
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn install state path...");
+    const yarnInstallStatePath = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("installStatePath");
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn patch folder...");
+    const yarnPatchFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("patchFolder");
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn PnP unplugged folder...");
+    const yarnPnpUnpluggedFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder");
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn virtual folder...");
+    const yarnVirtualFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("virtualFolder");
     const cachePaths = [
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("cacheFolder"),
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder"),
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("installStatePath"),
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("patchFolder"),
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder"),
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("virtualFolder"),
+        yarnCacheFolder,
+        yarnDefferedVersionFolder,
+        yarnInstallStatePath,
+        yarnPatchFolder,
+        yarnPnpUnpluggedFolder,
+        yarnVirtualFolder,
         ".yarn",
         ".pnp.cjs",
         ".pnp.loader.mjs",

--- a/dist/index.js
+++ b/dist/index.js
@@ -79482,7 +79482,8 @@ module.exports.implForWrapper = function (wrapper) {
 
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   "A": () => (/* binding */ getCacheInformation)
+/* harmony export */   "N": () => (/* binding */ getCachePaths),
+/* harmony export */   "a": () => (/* binding */ getCacheKey)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4278);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
@@ -79499,7 +79500,7 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 
 
 
-async function getCacheInformation() {
+async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
     const version = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].version */ .Z.version();
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Yarn version: ${version}`);
@@ -79510,22 +79511,24 @@ async function getCacheInformation() {
     }
     const lockFileHash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Lock file hash: ${lockFileHash}`);
-    const cacheInfo = {
-        key: `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}-${lockFileHash}`,
-        paths: [
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("cacheFolder"),
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder"),
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("installStatePath"),
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("patchFolder"),
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder"),
-            await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("virtualFolder"),
-            ".yarn",
-            ".pnp.cjs",
-            ".pnp.loader.mjs",
-        ],
-    };
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache information: ${JSON.stringify(cacheInfo, null, 4)}`);
-    return cacheInfo;
+    const cacheKey = `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}-${lockFileHash}`;
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache key: ${cacheKey}`);
+    return cacheKey;
+}
+async function getCachePaths() {
+    const cachePaths = [
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("cacheFolder"),
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder"),
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("installStatePath"),
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("patchFolder"),
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder"),
+        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("virtualFolder"),
+        ".yarn",
+        ".pnp.cjs",
+        ".pnp.loader.mjs",
+    ];
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
+    return cachePaths;
 }
 
 __webpack_async_result__();
@@ -79553,10 +79556,14 @@ async function main() {
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Enabling Yarn", async () => {
         await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].enable */ .Z.enable();
     });
-    const cacheInfo = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache information", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheInformation */ .A);
-    if (cacheInfo !== undefined) {
+    const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
+    let cachePaths = [];
+    if (cacheKey !== undefined) {
+        cachePaths = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache paths", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N);
+    }
+    if (cacheKey !== undefined) {
         const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {
-            const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cacheInfo.paths.slice(), cacheInfo.key);
+            const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);
             if (cacheId === undefined) {
                 _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning("Cache not found");
                 return false;
@@ -79571,9 +79578,9 @@ async function main() {
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
         return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].install */ .Z.install();
     });
-    if (cacheInfo !== undefined) {
+    if (cacheKey !== undefined) {
         await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Saving cache", async () => {
-            return _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cacheInfo.paths.slice(), cacheInfo.key);
+            return _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
         });
     }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,14 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import yarn from "./yarn.js";
 
-interface CacheInformation {
-  key: string;
-  paths: string[];
-}
-
-export async function getCacheInformation(): Promise<
-  CacheInformation | undefined
-> {
+export async function getCacheKey(): Promise<string | undefined> {
   core.info("Getting Yarn version...");
   const version = await yarn.version();
   core.info(`Yarn version: ${version}`);
@@ -24,21 +17,25 @@ export async function getCacheInformation(): Promise<
   const lockFileHash = await hashFile("yarn.lock", { algorithm: "md5" });
   core.info(`Lock file hash: ${lockFileHash}`);
 
-  const cacheInfo = {
-    key: `yarn-install-action-${os.type()}-${version}-${lockFileHash}`,
-    paths: [
-      await yarn.getConfig("cacheFolder"),
-      await yarn.getConfig("deferredVersionFolder"),
-      await yarn.getConfig("installStatePath"),
-      await yarn.getConfig("patchFolder"),
-      await yarn.getConfig("pnpUnpluggedFolder"),
-      await yarn.getConfig("virtualFolder"),
-      ".yarn",
-      ".pnp.cjs",
-      ".pnp.loader.mjs",
-    ],
-  };
-  core.info(`Using cache information: ${JSON.stringify(cacheInfo, null, 4)}`);
+  const cacheKey = `yarn-install-action-${os.type()}-${version}-${lockFileHash}`;
+  core.info(`Using cache key: ${cacheKey}`);
 
-  return cacheInfo;
+  return cacheKey;
+}
+
+export async function getCachePaths(): Promise<string[]> {
+  const cachePaths = [
+    await yarn.getConfig("cacheFolder"),
+    await yarn.getConfig("deferredVersionFolder"),
+    await yarn.getConfig("installStatePath"),
+    await yarn.getConfig("patchFolder"),
+    await yarn.getConfig("pnpUnpluggedFolder"),
+    await yarn.getConfig("virtualFolder"),
+    ".yarn",
+    ".pnp.cjs",
+    ".pnp.loader.mjs",
+  ];
+  core.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
+
+  return cachePaths;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,7 +7,6 @@ import yarn from "./yarn.js";
 export async function getCacheKey(): Promise<string | undefined> {
   core.info("Getting Yarn version...");
   const version = await yarn.version();
-  core.info(`Yarn version: ${version}`);
 
   core.info("Calculating lock file hash...");
   if (!fs.existsSync("yarn.lock")) {
@@ -15,7 +14,6 @@ export async function getCacheKey(): Promise<string | undefined> {
     return undefined;
   }
   const lockFileHash = await hashFile("yarn.lock", { algorithm: "md5" });
-  core.info(`Lock file hash: ${lockFileHash}`);
 
   const cacheKey = `yarn-install-action-${os.type()}-${version}-${lockFileHash}`;
   core.info(`Using cache key: ${cacheKey}`);
@@ -24,13 +22,33 @@ export async function getCacheKey(): Promise<string | undefined> {
 }
 
 export async function getCachePaths(): Promise<string[]> {
+  core.info("Getting Yarn cache folder...");
+  const yarnCacheFolder = await yarn.getConfig("cacheFolder");
+
+  core.info("Getting Yarn deferred version folder...");
+  const yarnDefferedVersionFolder = await yarn.getConfig(
+    "deferredVersionFolder",
+  );
+
+  core.info("Getting Yarn install state path...");
+  const yarnInstallStatePath = await yarn.getConfig("installStatePath");
+
+  core.info("Getting Yarn patch folder...");
+  const yarnPatchFolder = await yarn.getConfig("patchFolder");
+
+  core.info("Getting Yarn PnP unplugged folder...");
+  const yarnPnpUnpluggedFolder = await yarn.getConfig("pnpUnpluggedFolder");
+
+  core.info("Getting Yarn virtual folder...");
+  const yarnVirtualFolder = await yarn.getConfig("virtualFolder");
+
   const cachePaths = [
-    await yarn.getConfig("cacheFolder"),
-    await yarn.getConfig("deferredVersionFolder"),
-    await yarn.getConfig("installStatePath"),
-    await yarn.getConfig("patchFolder"),
-    await yarn.getConfig("pnpUnpluggedFolder"),
-    await yarn.getConfig("virtualFolder"),
+    yarnCacheFolder,
+    yarnDefferedVersionFolder,
+    yarnInstallStatePath,
+    yarnPatchFolder,
+    yarnPnpUnpluggedFolder,
+    yarnVirtualFolder,
     ".yarn",
     ".pnp.cjs",
     ".pnp.loader.mjs",


### PR DESCRIPTION
This pull request resolves #144 by separating the `getCacheInformation` function into `getCacheKey` and `getCachePaths` functions. It also adjusts the log output of these functions.