### PR TITLE
Refactor Yarn Functions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79502,7 +79502,7 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 
 async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
-    const version = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].version */ .Z.version();
+    const version = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].version */ .ZP.version();
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
     if (!node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file not found, skipping cache`);
@@ -79515,17 +79515,17 @@ async function getCacheKey() {
 }
 async function getCachePaths() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn cache folder...");
-    const yarnCacheFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("cacheFolder");
+    const yarnCacheFolder = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("cacheFolder");
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn deferred version folder...");
-    const yarnDefferedVersionFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder");
+    const yarnDefferedVersionFolder = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("deferredVersionFolder");
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn install state path...");
-    const yarnInstallStatePath = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("installStatePath");
+    const yarnInstallStatePath = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("installStatePath");
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn patch folder...");
-    const yarnPatchFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("patchFolder");
+    const yarnPatchFolder = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("patchFolder");
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn PnP unplugged folder...");
-    const yarnPnpUnpluggedFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder");
+    const yarnPnpUnpluggedFolder = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("pnpUnpluggedFolder");
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn virtual folder...");
-    const yarnVirtualFolder = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].getConfig */ .Z.getConfig("virtualFolder");
+    const yarnVirtualFolder = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("virtualFolder");
     const cachePaths = [
         yarnCacheFolder,
         yarnDefferedVersionFolder,
@@ -79564,7 +79564,7 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 async function main() {
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Enabling Yarn", async () => {
-        await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .W)();
+        await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
     });
     const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
     let cachePaths = [];
@@ -79586,7 +79586,7 @@ async function main() {
         }
     }
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
-        return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].install */ .Z.install();
+        return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].install */ .ZP.install();
     });
     if (cacheKey !== undefined) {
         await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Saving cache", async () => {
@@ -79605,8 +79605,9 @@ __webpack_async_result__();
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   "W": () => (/* binding */ enableYarn),
-/* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */   "Wd": () => (/* binding */ enableYarn),
+/* harmony export */   "ZP": () => (__WEBPACK_DEFAULT_EXPORT__),
+/* harmony export */   "io": () => (/* binding */ getYarnConfig)
 /* harmony export */ });
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
@@ -79614,7 +79615,7 @@ __webpack_async_result__();
 async function enableYarn() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
 }
-async function getConfig(name) {
+async function getYarnConfig(name) {
     const prom = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
         silent: true,
     });
@@ -79636,7 +79637,7 @@ async function version() {
     });
     return res.stdout.trim();
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ getConfig, install, version });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ install, version });
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -79586,7 +79586,7 @@ async function main() {
         }
     }
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
-        return _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].install */ .ZP.install();
+        return (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .yarnInstall */ .Or)();
     });
     if (cacheKey !== undefined) {
         await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Saving cache", async () => {
@@ -79605,6 +79605,7 @@ __webpack_async_result__();
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "Or": () => (/* binding */ yarnInstall),
 /* harmony export */   "Wd": () => (/* binding */ enableYarn),
 /* harmony export */   "ZP": () => (__WEBPACK_DEFAULT_EXPORT__),
 /* harmony export */   "io": () => (/* binding */ getYarnConfig)
@@ -79622,7 +79623,7 @@ async function getYarnConfig(name) {
     const jsonData = (await prom).stdout;
     return JSON.parse(jsonData).effective;
 }
-async function install() {
+async function yarnInstall() {
     const env = process.env;
     // Prevent `yarn install` from outputting group log messages.
     env["GITHUB_ACTIONS"] = "";
@@ -79637,7 +79638,7 @@ async function version() {
     });
     return res.stdout.trim();
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ install, version });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ version });
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -79502,7 +79502,7 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 
 async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
-    const version = await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].version */ .ZP.version();
+    const version = await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
     if (!node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file not found, skipping cache`);
@@ -79606,8 +79606,8 @@ __webpack_async_result__();
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "Or": () => (/* binding */ yarnInstall),
+/* harmony export */   "Vh": () => (/* binding */ getYarnVersion),
 /* harmony export */   "Wd": () => (/* binding */ enableYarn),
-/* harmony export */   "ZP": () => (__WEBPACK_DEFAULT_EXPORT__),
 /* harmony export */   "io": () => (/* binding */ getYarnConfig)
 /* harmony export */ });
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
@@ -79632,13 +79632,12 @@ async function yarnInstall() {
     env["CI"] = "";
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["yarn", "install"], { env });
 }
-async function version() {
+async function getYarnVersion() {
     const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "--version"], {
         silent: true,
     });
     return res.stdout.trim();
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ version });
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -79564,7 +79564,7 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 async function main() {
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Enabling Yarn", async () => {
-        await _yarn_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].enable */ .Z.enable();
+        await (0,_yarn_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .W)();
     });
     const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
     let cachePaths = [];
@@ -79605,12 +79605,13 @@ __webpack_async_result__();
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "W": () => (/* binding */ enableYarn),
 /* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
 
-async function enable() {
+async function enableYarn() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
 }
 async function getConfig(name) {
@@ -79635,7 +79636,7 @@ async function version() {
     });
     return res.stdout.trim();
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ enable, getConfig, install, version });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ getConfig, install, version });
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -79617,11 +79617,10 @@ async function enableYarn() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
 }
 async function getYarnConfig(name) {
-    const prom = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
+    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
         silent: true,
     });
-    const jsonData = (await prom).stdout;
-    return JSON.parse(jsonData).effective;
+    return JSON.parse(res.stdout).effective;
 }
 async function yarnInstall() {
     const env = process.env;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,11 +2,11 @@ import * as core from "@actions/core";
 import { hashFile } from "hasha";
 import fs from "node:fs";
 import os from "node:os";
-import yarn, { getYarnConfig } from "./yarn.js";
+import { getYarnConfig, getYarnVersion } from "./yarn.js";
 
 export async function getCacheKey(): Promise<string | undefined> {
   core.info("Getting Yarn version...");
-  const version = await yarn.version();
+  const version = await getYarnVersion();
 
   core.info("Calculating lock file hash...");
   if (!fs.existsSync("yarn.lock")) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@ import * as core from "@actions/core";
 import { hashFile } from "hasha";
 import fs from "node:fs";
 import os from "node:os";
-import yarn from "./yarn.js";
+import yarn, { getYarnConfig } from "./yarn.js";
 
 export async function getCacheKey(): Promise<string | undefined> {
   core.info("Getting Yarn version...");
@@ -23,24 +23,24 @@ export async function getCacheKey(): Promise<string | undefined> {
 
 export async function getCachePaths(): Promise<string[]> {
   core.info("Getting Yarn cache folder...");
-  const yarnCacheFolder = await yarn.getConfig("cacheFolder");
+  const yarnCacheFolder = await getYarnConfig("cacheFolder");
 
   core.info("Getting Yarn deferred version folder...");
-  const yarnDefferedVersionFolder = await yarn.getConfig(
+  const yarnDefferedVersionFolder = await getYarnConfig(
     "deferredVersionFolder",
   );
 
   core.info("Getting Yarn install state path...");
-  const yarnInstallStatePath = await yarn.getConfig("installStatePath");
+  const yarnInstallStatePath = await getYarnConfig("installStatePath");
 
   core.info("Getting Yarn patch folder...");
-  const yarnPatchFolder = await yarn.getConfig("patchFolder");
+  const yarnPatchFolder = await getYarnConfig("patchFolder");
 
   core.info("Getting Yarn PnP unplugged folder...");
-  const yarnPnpUnpluggedFolder = await yarn.getConfig("pnpUnpluggedFolder");
+  const yarnPnpUnpluggedFolder = await getYarnConfig("pnpUnpluggedFolder");
 
   core.info("Getting Yarn virtual folder...");
-  const yarnVirtualFolder = await yarn.getConfig("virtualFolder");
+  const yarnVirtualFolder = await getYarnConfig("virtualFolder");
 
   const cachePaths = [
     yarnCacheFolder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
-import yarn, { enableYarn } from "./yarn.js";
+import { enableYarn, yarnInstall } from "./yarn.js";
 
 async function main(): Promise<void> {
   await core.group("Enabling Yarn", async () => {
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   }
 
   await core.group("Installing dependencies", async () => {
-    return yarn.install();
+    return yarnInstall();
   });
 
   if (cacheKey !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
-import yarn from "./yarn.js";
+import yarn, { enableYarn } from "./yarn.js";
 
 async function main(): Promise<void> {
   await core.group("Enabling Yarn", async () => {
-    await yarn.enable();
+    await enableYarn();
   });
 
   const cacheKey = await core.group("Getting cache key", getCacheKey);

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -16,9 +16,9 @@ beforeEach(() => {
 });
 
 it("should enable Yarn", async () => {
-  const yarn = (await import("./yarn.js")).default;
+  const { enableYarn } = await import("./yarn.js");
 
-  await yarn.enable();
+  await enableYarn();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
   expect(mock.exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"]);

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -48,9 +48,9 @@ it("should get Yarn config", async () => {
 });
 
 it("should install package using Yarn", async () => {
-  const yarn = (await import("./yarn.js")).default;
+  const { yarnInstall } = await import("./yarn.js");
 
-  await yarn.install();
+  await yarnInstall();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
   expect(mock.exec).toHaveBeenCalledWith("corepack", ["yarn", "install"], {

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -64,7 +64,7 @@ it("should install package using Yarn", async () => {
 });
 
 it("should get Yarn version", async () => {
-  const yarn = (await import("./yarn.js")).default;
+  const { getYarnVersion } = await import("./yarn.js");
 
   mock.getExecOutput.mockResolvedValueOnce({
     exitCode: 0,
@@ -72,7 +72,7 @@ it("should get Yarn version", async () => {
     stderr: "",
   });
 
-  const version = await yarn.version();
+  const version = await getYarnVersion();
 
   expect(mock.getExecOutput).toHaveBeenCalledTimes(1);
   expect(mock.getExecOutput).toHaveBeenCalledWith(

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -25,7 +25,7 @@ it("should enable Yarn", async () => {
 });
 
 it("should get Yarn config", async () => {
-  const yarn = (await import("./yarn.js")).default;
+  const { getYarnConfig } = await import("./yarn.js");
 
   mock.getExecOutput.mockResolvedValueOnce({
     exitCode: 0,
@@ -33,7 +33,7 @@ it("should get Yarn config", async () => {
     stderr: "",
   });
 
-  const value = await yarn.getConfig("globalFolder");
+  const value = await getYarnConfig("globalFolder");
 
   expect(mock.getExecOutput).toHaveBeenCalledTimes(1);
   expect(mock.getExecOutput).toHaveBeenCalledWith(

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -16,7 +16,7 @@ export async function getYarnConfig(name: string): Promise<string> {
   return JSON.parse(jsonData).effective;
 }
 
-async function install(): Promise<void> {
+export async function yarnInstall(): Promise<void> {
   const env = process.env as { [key: string]: string };
 
   // Prevent `yarn install` from outputting group log messages.
@@ -36,4 +36,4 @@ async function version() {
   return res.stdout.trim();
 }
 
-export default { install, version };
+export default { version };

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -5,15 +5,14 @@ export async function enableYarn(): Promise<void> {
 }
 
 export async function getYarnConfig(name: string): Promise<string> {
-  const prom = await getExecOutput(
+  const res = await getExecOutput(
     "corepack",
     ["yarn", "config", name, "--json"],
     {
       silent: true,
     },
   );
-  const jsonData = (await prom).stdout;
-  return JSON.parse(jsonData).effective;
+  return JSON.parse(res.stdout).effective;
 }
 
 export async function yarnInstall(): Promise<void> {

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,6 +1,6 @@
 import { exec, getExecOutput } from "@actions/exec";
 
-async function enable(): Promise<void> {
+export async function enableYarn(): Promise<void> {
   await exec("corepack", ["enable", "yarn"]);
 }
 
@@ -36,4 +36,4 @@ async function version() {
   return res.stdout.trim();
 }
 
-export default { enable, getConfig, install, version };
+export default { getConfig, install, version };

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -4,7 +4,7 @@ export async function enableYarn(): Promise<void> {
   await exec("corepack", ["enable", "yarn"]);
 }
 
-async function getConfig(name: string): Promise<string> {
+export async function getYarnConfig(name: string): Promise<string> {
   const prom = await getExecOutput(
     "corepack",
     ["yarn", "config", name, "--json"],
@@ -36,4 +36,4 @@ async function version() {
   return res.stdout.trim();
 }
 
-export default { getConfig, install, version };
+export default { install, version };

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -29,11 +29,9 @@ export async function yarnInstall(): Promise<void> {
   await exec("corepack", ["yarn", "install"], { env });
 }
 
-async function version() {
+export async function getYarnVersion() {
   const res = await getExecOutput("corepack", ["yarn", "--version"], {
     silent: true,
   });
   return res.stdout.trim();
 }
-
-export default { version };


### PR DESCRIPTION
This pull request resolves #148 by renaming functions inside the `src/yarn.ts` file as follows:
- Renaming the `yarn.enable` function to `enableYarn`.
- Renaming the `yarn.getConfig` function to `getYarnConfig`.
- Renaming the `yarn.install` function to `yarnInstall`.
- Renaming the `yarn.version` function to `getYarnVersion`.

This change also modifies functions to be exported individually and refactors the `getYarnConfig` function by removing unused `await`.