### PR TITLE
Organize Main Function to Separate File

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79555,6 +79555,27 @@ __webpack_async_result__();
 /***/ ((module, __unused_webpack___webpack_exports__, __nccwpck_require__) => {
 
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4278);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _main_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(7181);
+var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_main_js__WEBPACK_IMPORTED_MODULE_1__]);
+_main_js__WEBPACK_IMPORTED_MODULE_1__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
+
+
+(0,_main_js__WEBPACK_IMPORTED_MODULE_1__/* .main */ .D)().catch((err) => _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(err));
+
+__webpack_async_result__();
+} catch(e) { __webpack_async_result__(e); } });
+
+/***/ }),
+
+/***/ 7181:
+/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
+
+__nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "D": () => (/* binding */ main)
+/* harmony export */ });
 /* harmony import */ var _actions_cache__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(294);
 /* harmony import */ var _actions_cache__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_cache__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(4278);
@@ -79592,7 +79613,6 @@ async function main() {
         return _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
     });
 }
-main().catch((err) => _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(err));
 
 __webpack_async_result__();
 } catch(e) { __webpack_async_result__(e); } });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,4 @@
-import * as cache from "@actions/cache";
 import * as core from "@actions/core";
-import { getCacheKey, getCachePaths } from "./cache.js";
-import { enableYarn, yarnInstall } from "./yarn/index.js";
-
-async function main(): Promise<void> {
-  await core.group("Enabling Yarn", async () => {
-    await enableYarn();
-  });
-
-  const cacheKey = await core.group("Getting cache key", getCacheKey);
-  const cachePaths = await core.group("Getting cache paths", getCachePaths);
-
-  const cacheFound = await core.group("Restoring cache", async () => {
-    const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
-    if (cacheId === undefined) {
-      core.warning("Cache not found");
-      return false;
-    }
-    return true;
-  });
-
-  if (cacheFound) {
-    core.info("Cache restored successfully");
-    return;
-  }
-
-  await core.group("Installing dependencies", async () => {
-    return yarnInstall();
-  });
-
-  await core.group("Saving cache", async () => {
-    return cache.saveCache(cachePaths.slice(), cacheKey);
-  });
-}
+import { main } from "./main.js";
 
 main().catch((err) => core.setFailed(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,35 @@
+import * as cache from "@actions/cache";
+import * as core from "@actions/core";
+import { getCacheKey, getCachePaths } from "./cache.js";
+import { enableYarn, yarnInstall } from "./yarn/index.js";
+
+export async function main(): Promise<void> {
+  await core.group("Enabling Yarn", async () => {
+    await enableYarn();
+  });
+
+  const cacheKey = await core.group("Getting cache key", getCacheKey);
+  const cachePaths = await core.group("Getting cache paths", getCachePaths);
+
+  const cacheFound = await core.group("Restoring cache", async () => {
+    const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
+    if (cacheId === undefined) {
+      core.warning("Cache not found");
+      return false;
+    }
+    return true;
+  });
+
+  if (cacheFound) {
+    core.info("Cache restored successfully");
+    return;
+  }
+
+  await core.group("Installing dependencies", async () => {
+    return yarnInstall();
+  });
+
+  await core.group("Saving cache", async () => {
+    return cache.saveCache(cachePaths.slice(), cacheKey);
+  });
+}


### PR DESCRIPTION
This pull request resolves #156 by simply moving the `main` function from the `src/index.ts` file to a new `src/main.ts` file.