### PR TITLE
Refactor Steps for Getting Yarn Paths for Cache Paths

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79527,7 +79527,7 @@ async function getCachePaths() {
         { name: "Yarn PnP unplugged folder", config: "pnpUnpluggedFolder" },
         { name: "Yarn virtual folder", config: "virtualFolder" },
     ];
-    const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+    const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
     for (const { name, config } of yarnConfigs) {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Getting ${name}...`);
         cachePaths.push(await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)(config));

--- a/dist/index.js
+++ b/dist/index.js
@@ -79519,29 +79519,19 @@ async function getCacheKey() {
     return cacheKey;
 }
 async function getCachePaths() {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn cache folder...");
-    const yarnCacheFolder = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("cacheFolder");
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn deferred version folder...");
-    const yarnDefferedVersionFolder = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("deferredVersionFolder");
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn install state path...");
-    const yarnInstallStatePath = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("installStatePath");
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn patch folder...");
-    const yarnPatchFolder = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("patchFolder");
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn PnP unplugged folder...");
-    const yarnPnpUnpluggedFolder = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("pnpUnpluggedFolder");
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn virtual folder...");
-    const yarnVirtualFolder = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)("virtualFolder");
-    const cachePaths = [
-        yarnCacheFolder,
-        yarnDefferedVersionFolder,
-        yarnInstallStatePath,
-        yarnPatchFolder,
-        yarnPnpUnpluggedFolder,
-        yarnVirtualFolder,
-        ".yarn",
-        ".pnp.cjs",
-        ".pnp.loader.mjs",
+    const yarnConfigs = [
+        { name: "Yarn cache folder", config: "cacheFolder" },
+        { name: "Yarn deferred version folder", config: "deferredVersionFolder" },
+        { name: "Yarn install state path", config: "installStatePath" },
+        { name: "Yarn patch folder", config: "patchFolder" },
+        { name: "Yarn PnP unplugged folder", config: "pnpUnpluggedFolder" },
+        { name: "Yarn virtual folder", config: "virtualFolder" },
     ];
+    const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+    for (const { name, config } of yarnConfigs) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Getting ${name}...`);
+        cachePaths.push(await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)(config));
+    }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
     return cachePaths;
 }

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -89,14 +89,14 @@ it("should get the cache paths", async () => {
   const cachePaths = await getCachePaths();
 
   expect(cachePaths).toStrictEqual([
+    ".yarn",
+    ".pnp.cjs",
+    ".pnp.loader.mjs",
     ".yarn/cache",
     ".yarn/versions",
     ".yarn/install-state.gz",
     ".yarn/patches",
     ".yarn/unplugged",
     ".yarn/__virtual__",
-    ".yarn",
-    ".pnp.cjs",
-    ".pnp.loader.mjs",
   ]);
 });

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -89,7 +89,6 @@ it("should get the cache paths", async () => {
   const cachePaths = await getCachePaths();
 
   expect(cachePaths).toStrictEqual([
-    ".yarn",
     ".pnp.cjs",
     ".pnp.loader.mjs",
     ".yarn/cache",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -26,37 +26,20 @@ export async function getCacheKey(): Promise<string> {
 }
 
 export async function getCachePaths(): Promise<string[]> {
-  core.info("Getting Yarn cache folder...");
-  const yarnCacheFolder = await getYarnConfig("cacheFolder");
-
-  core.info("Getting Yarn deferred version folder...");
-  const yarnDefferedVersionFolder = await getYarnConfig(
-    "deferredVersionFolder",
-  );
-
-  core.info("Getting Yarn install state path...");
-  const yarnInstallStatePath = await getYarnConfig("installStatePath");
-
-  core.info("Getting Yarn patch folder...");
-  const yarnPatchFolder = await getYarnConfig("patchFolder");
-
-  core.info("Getting Yarn PnP unplugged folder...");
-  const yarnPnpUnpluggedFolder = await getYarnConfig("pnpUnpluggedFolder");
-
-  core.info("Getting Yarn virtual folder...");
-  const yarnVirtualFolder = await getYarnConfig("virtualFolder");
-
-  const cachePaths = [
-    yarnCacheFolder,
-    yarnDefferedVersionFolder,
-    yarnInstallStatePath,
-    yarnPatchFolder,
-    yarnPnpUnpluggedFolder,
-    yarnVirtualFolder,
-    ".yarn",
-    ".pnp.cjs",
-    ".pnp.loader.mjs",
+  const yarnConfigs = [
+    { name: "Yarn cache folder", config: "cacheFolder" },
+    { name: "Yarn deferred version folder", config: "deferredVersionFolder" },
+    { name: "Yarn install state path", config: "installStatePath" },
+    { name: "Yarn patch folder", config: "patchFolder" },
+    { name: "Yarn PnP unplugged folder", config: "pnpUnpluggedFolder" },
+    { name: "Yarn virtual folder", config: "virtualFolder" },
   ];
+
+  const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+  for (const { name, config } of yarnConfigs) {
+    core.info(`Getting ${name}...`);
+    cachePaths.push(await getYarnConfig(config));
+  }
   core.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
 
   return cachePaths;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -35,7 +35,7 @@ export async function getCachePaths(): Promise<string[]> {
     { name: "Yarn virtual folder", config: "virtualFolder" },
   ];
 
-  const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+  const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
   for (const { name, config } of yarnConfigs) {
     core.info(`Getting ${name}...`);
     cachePaths.push(await getYarnConfig(config));


### PR DESCRIPTION
This pull request resolves #158 by refactoring the lines responsible for getting Yarn paths in the `getCachePaths`  function. It also removes the `.yarn` directory from the cache paths.