### PR TITLE
Refactor Flow in `getCacheKey` Function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79503,17 +79503,14 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
     const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
+    let cacheKey = `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}`;
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
-    let lockFileHash = undefined;
     if (node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
-        lockFileHash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
+        const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
+        cacheKey += `-${hash}`;
     }
     else {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file could not be found, using empty hash`);
-    }
-    let cacheKey = `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}`;
-    if (lockFileHash !== undefined) {
-        cacheKey += `-${lockFileHash}`;
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache key: ${cacheKey}`);
     return cacheKey;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,20 +8,17 @@ export async function getCacheKey(): Promise<string> {
   core.info("Getting Yarn version...");
   const version = await getYarnVersion();
 
+  let cacheKey = `yarn-install-action-${os.type()}-${version}`;
+
   core.info("Calculating lock file hash...");
-  let lockFileHash: string | undefined = undefined;
   if (fs.existsSync("yarn.lock")) {
-    lockFileHash = await hashFile("yarn.lock", { algorithm: "md5" });
+    const hash = await hashFile("yarn.lock", { algorithm: "md5" });
+    cacheKey += `-${hash}`;
   } else {
     core.warning(`Lock file could not be found, using empty hash`);
   }
 
-  let cacheKey = `yarn-install-action-${os.type()}-${version}`;
-  if (lockFileHash !== undefined) {
-    cacheKey += `-${lockFileHash}`;
-  }
   core.info(`Using cache key: ${cacheKey}`);
-
   return cacheKey;
 }
 


### PR DESCRIPTION
This pull request resolves #167 by refactoring flow in the `getCacheKey` function for constructing the cache key if a lock file does not exist in the project.