### PR TITLE
Test Log Output in Get Cache Information Functions

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -62,15 +62,14 @@ describe("Getting the cache key", () => {
     });
 
     const cacheKey = await getCacheKey();
+    const expectedCacheKey = `yarn-install-action-${os.type()}-1.2.3-b1484caea0bbcbfa9a3a32591e3cad5d`;
 
     expect(logs).toStrictEqual([
       "Getting Yarn version...",
       "Calculating lock file hash...",
-      `Using cache key: yarn-install-action-${os.type()}-1.2.3-b1484caea0bbcbfa9a3a32591e3cad5d`,
+      `Using cache key: ${expectedCacheKey}`,
     ]);
-    expect(cacheKey).toBe(
-      `yarn-install-action-${os.type()}-1.2.3-b1484caea0bbcbfa9a3a32591e3cad5d`,
-    );
+    expect(cacheKey).toBe(expectedCacheKey);
   });
 
   it("should get the cache key if there is no lock file", async () => {
@@ -79,14 +78,15 @@ describe("Getting the cache key", () => {
     mock.fs.existsSync.mockReturnValue(false);
 
     const cacheKey = await getCacheKey();
+    const expectedCacheKey = `yarn-install-action-${os.type()}-1.2.3`;
 
     expect(logs).toStrictEqual([
       "Getting Yarn version...",
       "Calculating lock file hash...",
       "Lock file could not be found, using empty hash",
-      `Using cache key: yarn-install-action-${os.type()}-1.2.3`,
+      `Using cache key: ${expectedCacheKey}`,
     ]);
-    expect(cacheKey).toBe(`yarn-install-action-${os.type()}-1.2.3`);
+    expect(cacheKey).toBe(expectedCacheKey);
   });
 });
 
@@ -112,7 +112,6 @@ it("should get the cache paths", async () => {
   });
 
   const cachePaths = await getCachePaths();
-
   const expectedCachePaths = [
     ".pnp.cjs",
     ".pnp.loader.mjs",

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -29,22 +29,22 @@ jest.unstable_mockModule("./yarn.js", () => ({
   getYarnVersion: mock.getYarnVersion,
 }));
 
+let logs: (string | Error)[] = [];
+
 beforeEach(() => {
   jest.clearAllMocks();
+
+  logs = [];
+  mock.core.info.mockImplementation((message) => {
+    logs.push(message);
+  });
+  mock.core.warning.mockImplementation((message) => {
+    logs.push(message);
+  });
 });
 
 describe("Getting the cache key", () => {
-  let logs: (string | Error)[] = [];
-
   beforeEach(() => {
-    logs = [];
-    mock.core.info.mockImplementation((message) => {
-      logs.push(message);
-    });
-    mock.core.warning.mockImplementation((message) => {
-      logs.push(message);
-    });
-
     mock.getYarnVersion.mockResolvedValue("1.2.3");
   });
 
@@ -113,7 +113,7 @@ it("should get the cache paths", async () => {
 
   const cachePaths = await getCachePaths();
 
-  expect(cachePaths).toStrictEqual([
+  const expectedCachePaths = [
     ".pnp.cjs",
     ".pnp.loader.mjs",
     ".yarn/cache",
@@ -122,5 +122,16 @@ it("should get the cache paths", async () => {
     ".yarn/patches",
     ".yarn/unplugged",
     ".yarn/__virtual__",
+  ];
+
+  expect(logs).toStrictEqual([
+    "Getting Yarn cache folder...",
+    "Getting Yarn deferred version folder...",
+    "Getting Yarn install state path...",
+    "Getting Yarn patch folder...",
+    "Getting Yarn PnP unplugged folder...",
+    "Getting Yarn virtual folder...",
+    `Using cache paths: ${JSON.stringify(expectedCachePaths, null, 4)}`,
   ]);
+  expect(cachePaths).toStrictEqual(expectedCachePaths);
 });


### PR DESCRIPTION
This pull request resolves #169 by adding log output testing for the `getCacheKey` and `getCachePaths` functions.