### PR TITLE
Improve Error Handling in Main Function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79635,9 +79635,16 @@ async function main() {
         return;
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Saving cache", async () => {
-        return _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
-    });
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Saving cache");
+    try {
+        await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to save cache: ${err.message}`);
+        return;
+    }
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
 }
 
 __webpack_async_result__();

--- a/dist/index.js
+++ b/dist/index.js
@@ -79577,7 +79577,13 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 async function main() {
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
-    await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
+    try {
+        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to enable Yarn: ${err.message}`);
+        return;
+    }
     const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
     const cachePaths = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache paths", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N);
     const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79595,7 +79595,17 @@ async function main() {
         return;
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    const cachePaths = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache paths", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N);
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache paths");
+    let cachePaths;
+    try {
+        cachePaths = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N)();
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache paths: ${err.message}`);
+        return;
+    }
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
     const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {
         const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);
         if (cacheId === undefined) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79625,9 +79625,16 @@ async function main() {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Cache restored successfully");
         return;
     }
-    await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Installing dependencies", async () => {
-        return (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .yarnInstall */ .Or)();
-    });
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Installing dependencies");
+    try {
+        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .yarnInstall */ .Or)();
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to install dependencies: ${err.message}`);
+        return;
+    }
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
     await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Saving cache", async () => {
         return _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -79606,14 +79606,21 @@ async function main() {
         return;
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Restoring cache");
+    let cacheFound;
+    try {
         const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);
-        if (cacheId === undefined) {
+        cacheFound = cacheId != undefined;
+        if (!cacheFound) {
             _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning("Cache not found");
-            return false;
         }
-        return true;
-    });
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to restore cache: ${err.message}`);
+        return;
+    }
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
     if (cacheFound) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Cache restored successfully");
         return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -79584,7 +79584,17 @@ async function main() {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to enable Yarn: ${err.message}`);
         return;
     }
-    const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache key");
+    let cacheKey;
+    try {
+        cacheKey = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a)();
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache key: ${err.message}`);
+        return;
+    }
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
     const cachePaths = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache paths", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N);
     const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {
         const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -251,4 +251,32 @@ describe("install Yarn dependencies", () => {
       "Failed to install dependencies: some error",
     ]);
   });
+
+  it("should failed to save cache", async () => {
+    const { saveCache } = await import("@actions/cache");
+    const { main } = await import("./main.js");
+
+    jest.mocked(saveCache).mockRejectedValue(new Error("some error"));
+
+    await main();
+
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Enabling Yarn...",
+      "Yarn enabled",
+      "::group::Getting cache key",
+      "::endgroup::",
+      "::group::Getting cache paths",
+      "::endgroup::",
+      "::group::Restoring cache",
+      "Cache not found",
+      "::endgroup::",
+      "::group::Installing dependencies",
+      "Dependencies installed",
+      "::endgroup::",
+      "::group::Saving cache",
+      "::endgroup::",
+      "Failed to save cache: some error",
+    ]);
+  });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -204,4 +204,26 @@ describe("install Yarn dependencies", () => {
       "Failed to get cache paths: some error",
     ]);
   });
+
+  it("should failed to restore cache", async () => {
+    const { restoreCache } = await import("@actions/cache");
+    const { main } = await import("./main.js");
+
+    jest.mocked(restoreCache).mockRejectedValue(new Error("some error"));
+
+    await main();
+
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Enabling Yarn...",
+      "Yarn enabled",
+      "::group::Getting cache key",
+      "::endgroup::",
+      "::group::Getting cache paths",
+      "::endgroup::",
+      "::group::Restoring cache",
+      "::endgroup::",
+      "Failed to restore cache: some error",
+    ]);
+  });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -226,4 +226,29 @@ describe("install Yarn dependencies", () => {
       "Failed to restore cache: some error",
     ]);
   });
+
+  it("should failed to install dependencies", async () => {
+    const { yarnInstall } = await import("./yarn/index.js");
+    const { main } = await import("./main.js");
+
+    jest.mocked(yarnInstall).mockRejectedValue(new Error("some error"));
+
+    await main();
+
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Enabling Yarn...",
+      "Yarn enabled",
+      "::group::Getting cache key",
+      "::endgroup::",
+      "::group::Getting cache paths",
+      "::endgroup::",
+      "::group::Restoring cache",
+      "Cache not found",
+      "::endgroup::",
+      "::group::Installing dependencies",
+      "::endgroup::",
+      "Failed to install dependencies: some error",
+    ]);
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,12 @@ import { enableYarn, yarnInstall } from "./yarn/index.js";
 
 export async function main(): Promise<void> {
   core.info("Enabling Yarn...");
-  await enableYarn();
+  try {
+    await enableYarn();
+  } catch (err) {
+    core.setFailed(`Failed to enable Yarn: ${err.message}`);
+    return;
+  }
 
   const cacheKey = await core.group("Getting cache key", getCacheKey);
   const cachePaths = await core.group("Getting cache paths", getCachePaths);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,9 +54,15 @@ export async function main(): Promise<void> {
     return;
   }
 
-  await core.group("Installing dependencies", async () => {
-    return yarnInstall();
-  });
+  core.startGroup("Installing dependencies");
+  try {
+    await yarnInstall();
+  } catch (err) {
+    core.endGroup();
+    core.setFailed(`Failed to install dependencies: ${err.message}`);
+    return;
+  }
+  core.endGroup();
 
   await core.group("Saving cache", async () => {
     return cache.saveCache(cachePaths.slice(), cacheKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,16 @@ export async function main(): Promise<void> {
   }
   core.endGroup();
 
-  const cachePaths = await core.group("Getting cache paths", getCachePaths);
+  core.startGroup("Getting cache paths");
+  let cachePaths: string[];
+  try {
+    cachePaths = await getCachePaths();
+  } catch (err) {
+    core.endGroup();
+    core.setFailed(`Failed to get cache paths: ${err.message}`);
+    return;
+  }
+  core.endGroup();
 
   const cacheFound = await core.group("Restoring cache", async () => {
     const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,14 +34,20 @@ export async function main(): Promise<void> {
   }
   core.endGroup();
 
-  const cacheFound = await core.group("Restoring cache", async () => {
+  core.startGroup("Restoring cache");
+  let cacheFound: boolean;
+  try {
     const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
-    if (cacheId === undefined) {
+    cacheFound = cacheId != undefined;
+    if (!cacheFound) {
       core.warning("Cache not found");
-      return false;
     }
-    return true;
-  });
+  } catch (err) {
+    core.endGroup();
+    core.setFailed(`Failed to restore cache: ${err.message}`);
+    return;
+  }
+  core.endGroup();
 
   if (cacheFound) {
     core.info("Cache restored successfully");

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,13 @@ export async function main(): Promise<void> {
   }
   core.endGroup();
 
-  await core.group("Saving cache", async () => {
-    return cache.saveCache(cachePaths.slice(), cacheKey);
-  });
+  core.startGroup("Saving cache");
+  try {
+    await cache.saveCache(cachePaths.slice(), cacheKey);
+  } catch (err) {
+    core.endGroup();
+    core.setFailed(`Failed to save cache: ${err.message}`);
+    return;
+  }
+  core.endGroup();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,17 @@ export async function main(): Promise<void> {
     return;
   }
 
-  const cacheKey = await core.group("Getting cache key", getCacheKey);
+  core.startGroup("Getting cache key");
+  let cacheKey: string;
+  try {
+    cacheKey = await getCacheKey();
+  } catch (err) {
+    core.endGroup();
+    core.setFailed(`Failed to get cache key: ${err.message}`);
+    return;
+  }
+  core.endGroup();
+
   const cachePaths = await core.group("Getting cache paths", getCachePaths);
 
   const cacheFound = await core.group("Restoring cache", async () => {


### PR DESCRIPTION
This pull request resolves #177 by improving error handling in each step of the `main` function, effectively increasing test coverage because each step will now return early instead of throwing an error on failure.