### PR TITLE
Rename Action to Setup Yarn Berry Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@main
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@main
 
       - name: Build Package
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@main
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@main
 
       - name: Check Format
         run: |
@@ -40,8 +40,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@v1.0.0
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v1.0.0
 
       - name: Test Package
         run: corepack yarn test
@@ -62,14 +62,14 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4.1.1
         with:
-          path: yarn-install-action
+          path: setup-yarn-action
           sparse-checkout: |
             action.yaml
             dist
           sparse-checkout-cone-mode: false
 
-      - name: Install Dependencies
-        uses: ./yarn-install-action
+      - name: Setup Yarn
+        uses: ./setup-yarn-action
 
       - name: Build Package
         run: corepack yarn pack
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4.1.1
         with:
-          path: yarn-install-action
+          path: setup-yarn-action
           sparse-checkout: |
             action.yaml
             dist
@@ -97,8 +97,8 @@ jobs:
           corepack enable yarn
           corepack yarn config set enableGlobalCache false
 
-      - name: Install Dependencies
-        uses: ./yarn-install-action
+      - name: Setup Yarn
+        uses: ./setup-yarn-action
 
       - name: Build Package
         run: corepack yarn pack

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Setup Yarn Berry Action
 
-[![version](https://img.shields.io/github/v/release/threeal/yarn-install-action?style=flat-square)](https://github.com/threeal/yarn-install-action/releases)
-[![license](https://img.shields.io/github/license/threeal/yarn-install-action?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/yarn-install-action/build.yaml?branch=main&label=build&style=flat-square)](https://github.com/threeal/yarn-install-action/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/yarn-install-action/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/yarn-install-action/actions/workflows/test.yaml)
+[![version](https://img.shields.io/github/v/release/threeal/setup-yarn-action?style=flat-square)](https://github.com/threeal/setup-yarn-action/releases)
+[![license](https://img.shields.io/github/license/threeal/setup-yarn-action?style=flat-square)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/setup-yarn-action/build.yaml?branch=main&label=build&style=flat-square)](https://github.com/threeal/setup-yarn-action/actions/workflows/build.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/setup-yarn-action/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/setup-yarn-action/actions/workflows/test.yaml)
 
 The Setup Yarn Berry Action is a [GitHub Action](https://github.com/features/actions) crafted for effortless installation of dependencies in a [Node.js](https://nodejs.org/en) package utilizing the [Yarn](https://yarnpkg.com/) package manager.
 Yarn is a fast, reliable, and secure dependency management tool for Node.js projects, offering features such as deterministic dependency resolution and offline capabilities.
@@ -39,8 +39,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@v1.0.0
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v1.0.0
 
       # Add more steps as needed for your workflow
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Yarn Install Action
+# Setup Yarn Berry Action
 
 [![version](https://img.shields.io/github/v/release/threeal/yarn-install-action?style=flat-square)](https://github.com/threeal/yarn-install-action/releases)
 [![license](https://img.shields.io/github/license/threeal/yarn-install-action?style=flat-square)](./LICENSE)
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/yarn-install-action/build.yaml?branch=main&label=build&style=flat-square)](https://github.com/threeal/yarn-install-action/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/yarn-install-action/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/yarn-install-action/actions/workflows/test.yaml)
 
-The Yarn Install Action is a [GitHub Action](https://github.com/features/actions) crafted for effortless installation of dependencies in a [Node.js](https://nodejs.org/en) package utilizing the [Yarn](https://yarnpkg.com/) package manager.
+The Setup Yarn Berry Action is a [GitHub Action](https://github.com/features/actions) crafted for effortless installation of dependencies in a [Node.js](https://nodejs.org/en) package utilizing the [Yarn](https://yarnpkg.com/) package manager.
 Yarn is a fast, reliable, and secure dependency management tool for Node.js projects, offering features such as deterministic dependency resolution and offline capabilities.
 
-This action is designed to streamline GitHub workflows for Node.js projects, enabling quick and efficient installation by supporting the caching of dependencies. Whether you're working on a small project or a complex application, the Yarn Install Action ensures a smooth and accelerated dependency setup for your Node.js packages.
+This action is designed to streamline GitHub workflows for Node.js projects, enabling quick and efficient installation by supporting the caching of dependencies. Whether you're working on a small project or a complex application, the Setup Yarn Berry Action ensures a smooth and accelerated dependency setup for your Node.js packages.
 
 ## Key Features
 
-The Yarn Install Action provides the following key features:
+The Setup Yarn Berry Action provides the following key features:
 
 - Install dependencies for a Node.js package using Yarn.
 - Automatic Yarn enablement using [Corepack](https://nodejs.org/api/corepack.html) before installation.
@@ -20,12 +20,12 @@ The Yarn Install Action provides the following key features:
 
 ## Usage
 
-To begin using the Yarn Install Action, refer to the [action.yaml](./action.yaml) file for detailed configuration options.
+To begin using the Setup Yarn Berry Action, refer to the [action.yaml](./action.yaml) file for detailed configuration options.
 If you are new to GitHub Actions, you can explore the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for a comprehensive overview.
 
 ### Example
 
-Here's a basic example demonstrating how to utilize the Yarn Install Action to install dependencies for a Node.js package using Yarn in your GitHub Actions workflow:
+Here's a basic example demonstrating how to utilize the Setup Yarn Berry Action to install dependencies for a Node.js package using Yarn in your GitHub Actions workflow:
 
 ```yaml
 name: Build

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: Yarn Install Action
+name: Setup Yarn Berry
 author: Alfi Maulana
 description: Install Node.js dependencies using Yarn with cache support
 branding:

--- a/dist/index.js
+++ b/dist/index.js
@@ -79503,7 +79503,7 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 async function getCacheKey() {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
     const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
-    let cacheKey = `yarn-install-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}`;
+    let cacheKey = `setup-yarn-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}`;
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
     if (node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
         const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -60,7 +60,7 @@ describe("Getting the cache key", () => {
     });
 
     const cacheKey = await getCacheKey();
-    const expectedCacheKey = `yarn-install-action-${os.type()}-1.2.3-b1484caea0bbcbfa9a3a32591e3cad5d`;
+    const expectedCacheKey = `setup-yarn-action-${os.type()}-1.2.3-b1484caea0bbcbfa9a3a32591e3cad5d`;
 
     expect(logs).toStrictEqual([
       "Getting Yarn version...",
@@ -77,7 +77,7 @@ describe("Getting the cache key", () => {
     jest.mocked(fs.existsSync).mockReturnValue(false);
 
     const cacheKey = await getCacheKey();
-    const expectedCacheKey = `yarn-install-action-${os.type()}-1.2.3`;
+    const expectedCacheKey = `setup-yarn-action-${os.type()}-1.2.3`;
 
     expect(logs).toStrictEqual([
       "Getting Yarn version...",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,7 +8,7 @@ export async function getCacheKey(): Promise<string> {
   core.info("Getting Yarn version...");
   const version = await getYarnVersion();
 
-  let cacheKey = `yarn-install-action-${os.type()}-${version}`;
+  let cacheKey = `setup-yarn-action-${os.type()}-${version}`;
 
   core.info("Calculating lock file hash...");
   if (fs.existsSync("yarn.lock")) {


### PR DESCRIPTION
This pull request resolves #166 by introducing the following changes:
- Renames the action to "Setup Yarn Berry Action".
- Changes the repository path to `threeal/setup-yarn-action`.
- Updates the recommended step name when using this action to "Setup Yarn".
- Prefixes cache with `setup-yarn-action`.