### PR TITLE
Add Support to Disable Cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,36 @@ jobs:
       - name: Build Package
         run: corepack yarn pack
 
+  test-action-without-cache:
+    name: Test Action Without Cache
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: threeal/nodejs-starter
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.1
+        with:
+          path: setup-yarn-action
+          sparse-checkout: |
+            action.yaml
+            dist
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Yarn
+        uses: ./setup-yarn-action
+        with:
+          cache: false
+
+      - name: Build Package
+        run: corepack yarn pack
+
   test-action-with-yarn-local-cache:
     name: Test Action With Yarn Local Cache
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The Setup Yarn Berry Action provides the following key features:
 To begin using the Setup Yarn Berry Action, refer to the [action.yaml](./action.yaml) file for detailed configuration options.
 If you are new to GitHub Actions, you can explore the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for a comprehensive overview.
 
+### Inputs
+
+Here are the available input parameters for the Setup Yarn Berry Action:
+
+| Name    | Type              | Default | Description                                                |
+| ------- | ----------------- | ------- | ---------------------------------------------------------- |
+| `cache` | `true` or `false` | `true`  | Indicates whether to use caching during Yarn installation. |
+
 ### Example
 
 Here's a basic example demonstrating how to utilize the Setup Yarn Berry Action to install dependencies for a Node.js package using Yarn in your GitHub Actions workflow:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ jobs:
       # Add more steps as needed for your workflow
 ```
 
+#### Disabling Caching
+
+By default, caching is enabled. To disable caching, set the `cache` input parameter to `false` as shown below:
+
+```yaml
+- name: Setup Yarn Without Caching
+  uses: threeal/setup-yarn-action@v1.0.0
+  with:
+    cache: false
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ description: Install Node.js dependencies using Yarn with cache support
 branding:
   icon: chevrons-right
   color: black
+inputs:
+  cache:
+    description: Use caching during Yarn installation
+    default: true
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -79556,6 +79556,24 @@ __webpack_async_result__();
 
 /***/ }),
 
+/***/ 4885:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "G": () => (/* binding */ getInputs)
+/* harmony export */ });
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4278);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
+
+function getInputs() {
+    return {
+        cache: (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)("cache"),
+    };
+}
+
+
+/***/ }),
+
 /***/ 7181:
 /***/ ((module, __webpack_exports__, __nccwpck_require__) => {
 
@@ -79569,13 +79587,17 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _cache_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7907);
 /* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1913);
+/* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(4885);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_cache_js__WEBPACK_IMPORTED_MODULE_2__]);
 _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 
 
 
 
+
 async function main() {
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Getting action inputs...");
+    const inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_4__/* .getInputs */ .G)();
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
     try {
         await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
@@ -79584,46 +79606,48 @@ async function main() {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to enable Yarn: ${err.message}`);
         return;
     }
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache key");
     let cacheKey;
-    try {
-        cacheKey = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a)();
-    }
-    catch (err) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache key: ${err.message}`);
-        return;
-    }
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache paths");
     let cachePaths;
-    try {
-        cachePaths = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N)();
-    }
-    catch (err) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache paths: ${err.message}`);
-        return;
-    }
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Restoring cache");
-    let cacheFound;
-    try {
-        const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);
-        cacheFound = cacheId != undefined;
-        if (!cacheFound) {
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning("Cache not found");
+    if (inputs.cache) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache key");
+        try {
+            cacheKey = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a)();
         }
-    }
-    catch (err) {
+        catch (err) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache key: ${err.message}`);
+            return;
+        }
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to restore cache: ${err.message}`);
-        return;
-    }
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    if (cacheFound) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Cache restored successfully");
-        return;
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache paths");
+        try {
+            cachePaths = await (0,_cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N)();
+        }
+        catch (err) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get cache paths: ${err.message}`);
+            return;
+        }
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Restoring cache");
+        let cacheFound;
+        try {
+            const cacheId = await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(cachePaths.slice(), cacheKey);
+            cacheFound = cacheId != undefined;
+            if (!cacheFound) {
+                _actions_core__WEBPACK_IMPORTED_MODULE_1__.warning("Cache not found");
+            }
+        }
+        catch (err) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to restore cache: ${err.message}`);
+            return;
+        }
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+        if (cacheFound) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Cache restored successfully");
+            return;
+        }
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Installing dependencies");
     try {
@@ -79635,16 +79659,18 @@ async function main() {
         return;
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Saving cache");
-    try {
-        await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
-    }
-    catch (err) {
+    if (inputs.cache) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Saving cache");
+        try {
+            await _actions_cache__WEBPACK_IMPORTED_MODULE_0__.saveCache(cachePaths.slice(), cacheKey);
+        }
+        catch (err) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
+            _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to save cache: ${err.message}`);
+            return;
+        }
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to save cache: ${err.message}`);
-        return;
     }
-    _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
 }
 
 __webpack_async_result__();

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -1,0 +1,25 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@actions/core", () => ({
+  getBooleanInput: jest.fn(),
+}));
+
+beforeEach(async () => {
+  const { getBooleanInput } = await import("@actions/core");
+
+  jest.mocked(getBooleanInput).mockImplementation((name) => {
+    switch (name) {
+      case "cache":
+        return true;
+    }
+    throw new Error(`unknown input: ${name}`);
+  });
+});
+
+it("should get the action inputs", async () => {
+  const { getInputs } = await import("./inputs.js");
+
+  const inputs = getInputs();
+
+  expect(inputs).toStrictEqual({ cache: true });
+});

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,0 +1,7 @@
+import { getBooleanInput } from "@actions/core";
+
+export function getInputs() {
+  return {
+    cache: getBooleanInput("cache"),
+  };
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -23,6 +23,10 @@ jest.unstable_mockModule("./cache.js", () => ({
   getCachePaths: jest.fn(),
 }));
 
+jest.unstable_mockModule("./inputs.js", () => ({
+  getInputs: jest.fn(),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -36,6 +40,7 @@ describe("install Yarn dependencies", () => {
     const core = await import("@actions/core");
     const { enableYarn, yarnInstall } = await import("./yarn/index.js");
     const { getCacheKey, getCachePaths } = await import("./cache.js");
+    const { getInputs } = await import("./inputs.js");
 
     failed = false;
     logs = [];
@@ -90,6 +95,8 @@ describe("install Yarn dependencies", () => {
 
     jest.mocked(getCacheKey).mockResolvedValue("unavailable-key");
     jest.mocked(getCachePaths).mockResolvedValue(["some/path", "another/path"]);
+
+    jest.mocked(getInputs).mockReturnValue({ cache: true });
   });
 
   it("should failed to enable Yarn", async () => {
@@ -102,6 +109,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Failed to enable Yarn: some error",
     ]);
@@ -117,6 +125,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -135,6 +144,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -155,6 +165,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -177,6 +188,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(false);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -202,6 +214,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -227,6 +240,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(true);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -252,6 +266,7 @@ describe("install Yarn dependencies", () => {
 
     expect(failed).toBe(false);
     expect(logs).toStrictEqual([
+      "Getting action inputs...",
       "Enabling Yarn...",
       "Yarn enabled",
       "::group::Getting cache key",
@@ -270,5 +285,29 @@ describe("install Yarn dependencies", () => {
       "Cache unavailable-key saved",
       "::endgroup::",
     ]);
+  });
+
+  describe("with cache disabled", () => {
+    beforeEach(async () => {
+      const { getInputs } = await import("./inputs.js");
+
+      jest.mocked(getInputs).mockReturnValue({ cache: false });
+    });
+
+    it("should successfully install dependencies", async () => {
+      const { main } = await import("./main.js");
+
+      await main();
+
+      expect(failed).toBe(false);
+      expect(logs).toStrictEqual([
+        "Getting action inputs...",
+        "Enabling Yarn...",
+        "Yarn enabled",
+        "::group::Installing dependencies",
+        "Dependencies installed",
+        "::endgroup::",
+      ]);
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,12 @@ import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
 import { enableYarn, yarnInstall } from "./yarn/index.js";
+import { getInputs } from "./inputs.js";
 
 export async function main(): Promise<void> {
+  core.info("Getting action inputs...");
+  const inputs = getInputs();
+
   core.info("Enabling Yarn...");
   try {
     await enableYarn();
@@ -12,46 +16,48 @@ export async function main(): Promise<void> {
     return;
   }
 
-  core.startGroup("Getting cache key");
   let cacheKey: string;
-  try {
-    cacheKey = await getCacheKey();
-  } catch (err) {
-    core.endGroup();
-    core.setFailed(`Failed to get cache key: ${err.message}`);
-    return;
-  }
-  core.endGroup();
-
-  core.startGroup("Getting cache paths");
   let cachePaths: string[];
-  try {
-    cachePaths = await getCachePaths();
-  } catch (err) {
-    core.endGroup();
-    core.setFailed(`Failed to get cache paths: ${err.message}`);
-    return;
-  }
-  core.endGroup();
-
-  core.startGroup("Restoring cache");
-  let cacheFound: boolean;
-  try {
-    const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
-    cacheFound = cacheId != undefined;
-    if (!cacheFound) {
-      core.warning("Cache not found");
+  if (inputs.cache) {
+    core.startGroup("Getting cache key");
+    try {
+      cacheKey = await getCacheKey();
+    } catch (err) {
+      core.endGroup();
+      core.setFailed(`Failed to get cache key: ${err.message}`);
+      return;
     }
-  } catch (err) {
     core.endGroup();
-    core.setFailed(`Failed to restore cache: ${err.message}`);
-    return;
-  }
-  core.endGroup();
 
-  if (cacheFound) {
-    core.info("Cache restored successfully");
-    return;
+    core.startGroup("Getting cache paths");
+    try {
+      cachePaths = await getCachePaths();
+    } catch (err) {
+      core.endGroup();
+      core.setFailed(`Failed to get cache paths: ${err.message}`);
+      return;
+    }
+    core.endGroup();
+
+    core.startGroup("Restoring cache");
+    let cacheFound: boolean;
+    try {
+      const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
+      cacheFound = cacheId != undefined;
+      if (!cacheFound) {
+        core.warning("Cache not found");
+      }
+    } catch (err) {
+      core.endGroup();
+      core.setFailed(`Failed to restore cache: ${err.message}`);
+      return;
+    }
+    core.endGroup();
+
+    if (cacheFound) {
+      core.info("Cache restored successfully");
+      return;
+    }
   }
 
   core.startGroup("Installing dependencies");
@@ -64,13 +70,15 @@ export async function main(): Promise<void> {
   }
   core.endGroup();
 
-  core.startGroup("Saving cache");
-  try {
-    await cache.saveCache(cachePaths.slice(), cacheKey);
-  } catch (err) {
+  if (inputs.cache) {
+    core.startGroup("Saving cache");
+    try {
+      await cache.saveCache(cachePaths.slice(), cacheKey);
+    } catch (err) {
+      core.endGroup();
+      core.setFailed(`Failed to save cache: ${err.message}`);
+      return;
+    }
     core.endGroup();
-    core.setFailed(`Failed to save cache: ${err.message}`);
-    return;
   }
-  core.endGroup();
 }


### PR DESCRIPTION
This pull request resolves #180 by introducing the following changes:
- Adds the `cache` action input.
- Adds the `getInputs` function for retrieving the action inputs.
- Modifies steps in the `main` function to skip caching steps if the `cache` input is set to `false`.
- Adds a `test-action-without-cache` job in the `test` workflow.
- Adds a guide in the `README.md` on how to disable caching in the action.