### PR TITLE
Improve Error Handling in Get Cache Info Functions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79512,12 +79512,18 @@ async function getCacheKey() {
         throw new Error("Failed to get Yarn version");
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
-    if (node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
-        const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
-        cacheKey += `-${hash}`;
+    try {
+        if (node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
+            const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });
+            cacheKey += `-${hash}`;
+        }
+        else {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file could not be found, using empty hash`);
+        }
     }
-    else {
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Lock file could not be found, using empty hash`);
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Failed to calculate lock file hash: ${err.message}`);
+        throw new Error("Failed to calculate lock file hash");
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache key: ${cacheKey}`);
     return cacheKey;

--- a/dist/index.js
+++ b/dist/index.js
@@ -79529,6 +79529,7 @@ async function getCacheKey() {
     return cacheKey;
 }
 async function getCachePaths() {
+    const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
     const yarnConfigs = [
         { name: "Yarn cache folder", config: "cacheFolder" },
         { name: "Yarn deferred version folder", config: "deferredVersionFolder" },
@@ -79537,10 +79538,15 @@ async function getCachePaths() {
         { name: "Yarn PnP unplugged folder", config: "pnpUnpluggedFolder" },
         { name: "Yarn virtual folder", config: "virtualFolder" },
     ];
-    const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
     for (const { name, config } of yarnConfigs) {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Getting ${name}...`);
-        cachePaths.push(await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)(config));
+        try {
+            cachePaths.push(await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnConfig */ .io)(config));
+        }
+        catch (err) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Failed to get ${name}: ${err.message}`);
+            throw new Error(`Failed to get ${name}`);
+        }
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
     return cachePaths;

--- a/dist/index.js
+++ b/dist/index.js
@@ -79501,9 +79501,16 @@ hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (awa
 
 
 async function getCacheKey() {
+    let cacheKey = `setup-yarn-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}`;
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
-    const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
-    let cacheKey = `setup-yarn-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}-${version}`;
+    try {
+        const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
+        cacheKey += `-${version}`;
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Failed to get Yarn version: ${err.message}`);
+        throw new Error("Failed to get Yarn version");
+    }
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Calculating lock file hash...");
     if (node_fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync("yarn.lock")) {
         const hash = await (0,hasha__WEBPACK_IMPORTED_MODULE_4__/* .hashFile */ .Th)("yarn.lock", { algorithm: "md5" });

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -78,6 +78,23 @@ describe("get cache key", () => {
     ]);
   });
 
+  it("should failed to calculate lock file hash", async () => {
+    const { hashFile } = await import("hasha");
+    const { getCacheKey } = await import("./cache.js");
+
+    jest.mocked(hashFile).mockRejectedValue(new Error("some error"));
+
+    const prom = getCacheKey();
+
+    await expect(prom).rejects.toThrow("Failed to calculate lock file hash");
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Getting Yarn version...",
+      "Calculating lock file hash...",
+      "Failed to calculate lock file hash: some error",
+    ]);
+  });
+
   it("should get the cache key", async () => {
     const { getCacheKey } = await import("./cache.js");
 

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -158,6 +158,22 @@ describe("get cache paths", () => {
     });
   });
 
+  it("should failed to get Yarn config", async () => {
+    const { getYarnConfig } = await import("./yarn/index.js");
+    const { getCachePaths } = await import("./cache.js");
+
+    jest.mocked(getYarnConfig).mockRejectedValue(new Error("some error"));
+
+    const prom = getCachePaths();
+
+    await expect(prom).rejects.toThrow("Failed to get Yarn cache folder");
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Getting Yarn cache folder...",
+      "Failed to get Yarn cache folder: some error",
+    ]);
+  });
+
   it("should get the cache paths", async () => {
     const { getCachePaths } = await import("./cache.js");
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,10 +5,16 @@ import os from "node:os";
 import { getYarnConfig, getYarnVersion } from "./yarn/index.js";
 
 export async function getCacheKey(): Promise<string> {
-  core.info("Getting Yarn version...");
-  const version = await getYarnVersion();
+  let cacheKey = `setup-yarn-action-${os.type()}`;
 
-  let cacheKey = `setup-yarn-action-${os.type()}-${version}`;
+  core.info("Getting Yarn version...");
+  try {
+    const version = await getYarnVersion();
+    cacheKey += `-${version}`;
+  } catch (err) {
+    core.setFailed(`Failed to get Yarn version: ${err.message}`);
+    throw new Error("Failed to get Yarn version");
+  }
 
   core.info("Calculating lock file hash...");
   if (fs.existsSync("yarn.lock")) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -34,6 +34,8 @@ export async function getCacheKey(): Promise<string> {
 }
 
 export async function getCachePaths(): Promise<string[]> {
+  const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
+
   const yarnConfigs = [
     { name: "Yarn cache folder", config: "cacheFolder" },
     { name: "Yarn deferred version folder", config: "deferredVersionFolder" },
@@ -42,13 +44,16 @@ export async function getCachePaths(): Promise<string[]> {
     { name: "Yarn PnP unplugged folder", config: "pnpUnpluggedFolder" },
     { name: "Yarn virtual folder", config: "virtualFolder" },
   ];
-
-  const cachePaths = [".pnp.cjs", ".pnp.loader.mjs"];
   for (const { name, config } of yarnConfigs) {
     core.info(`Getting ${name}...`);
-    cachePaths.push(await getYarnConfig(config));
+    try {
+      cachePaths.push(await getYarnConfig(config));
+    } catch (err) {
+      core.setFailed(`Failed to get ${name}: ${err.message}`);
+      throw new Error(`Failed to get ${name}`);
+    }
   }
-  core.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
 
+  core.info(`Using cache paths: ${JSON.stringify(cachePaths, null, 4)}`);
   return cachePaths;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,11 +17,16 @@ export async function getCacheKey(): Promise<string> {
   }
 
   core.info("Calculating lock file hash...");
-  if (fs.existsSync("yarn.lock")) {
-    const hash = await hashFile("yarn.lock", { algorithm: "md5" });
-    cacheKey += `-${hash}`;
-  } else {
-    core.warning(`Lock file could not be found, using empty hash`);
+  try {
+    if (fs.existsSync("yarn.lock")) {
+      const hash = await hashFile("yarn.lock", { algorithm: "md5" });
+      cacheKey += `-${hash}`;
+    } else {
+      core.warning(`Lock file could not be found, using empty hash`);
+    }
+  } catch (err) {
+    core.setFailed(`Failed to calculate lock file hash: ${err.message}`);
+    throw new Error("Failed to calculate lock file hash");
   }
 
   core.info(`Using cache key: ${cacheKey}`);


### PR DESCRIPTION
This pull request resolves #182 by improving error handling in each step of the `getCacheKey` and `getCachePaths` functions, effectively also increasing test coverage.