### PR TITLE
Configure Jest to Run Tests Verbosely

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -14,5 +14,6 @@
   "preset": "ts-jest/presets/default-esm",
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
-  }
+  },
+  "verbose": true
 }


### PR DESCRIPTION
This pull request resolves #186 by configuring `verbose` option to `true` in the `jest.config.json` file.