### PR TITLE
Add Exec Yarn Function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79492,7 +79492,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(node_fs__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(612);
 /* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(node_os__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1913);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(5494);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([hasha__WEBPACK_IMPORTED_MODULE_4__]);
 hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 
@@ -79605,7 +79605,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(4278);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _cache_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7907);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1913);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(5494);
 /* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(4885);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_cache_js__WEBPACK_IMPORTED_MODULE_2__]);
 _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
@@ -79697,7 +79697,7 @@ __webpack_async_result__();
 
 /***/ }),
 
-/***/ 1913:
+/***/ 5494:
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -79713,6 +79713,26 @@ __nccwpck_require__.d(__webpack_exports__, {
 var exec = __nccwpck_require__(8434);
 // EXTERNAL MODULE: ./.yarn/cache/@actions-core-npm-1.10.1-3cb1000b4d-7a61446697.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(4278);
+;// CONCATENATED MODULE: ./src/yarn/exec.ts
+
+/**
+ * Execute a Yarn command with the given arguments.
+ *
+ * This function executes the Yarn command silently, without outputting anything to the standard output.
+ * Optionally, a callback can be provided to read the output from the command.
+ *
+ * @param args - The arguments of the Yarn command.
+ * @param stdlineCallback - A callback to be called when receiving a line from the standard output.
+ */
+async function execYarn(args, stdlineCallback) {
+    await (0,exec.exec)("corepack", ["yarn", ...args], {
+        silent: true,
+        listeners: {
+            stdline: stdlineCallback,
+        },
+    });
+}
+
 ;// CONCATENATED MODULE: ./src/yarn/install.ts
 
 
@@ -79730,14 +79750,9 @@ function printYarnInstallOutput(output) {
     }
 }
 async function yarnInstall() {
-    await (0,exec.exec)("corepack", ["yarn", "install", "--json"], {
-        silent: true,
-        listeners: {
-            stdline: (data) => {
-                const output = JSON.parse(data);
-                printYarnInstallOutput(output);
-            },
-        },
+    await execYarn(["install", "--json"], (data) => {
+        const output = JSON.parse(data);
+        printYarnInstallOutput(output);
     });
 }
 

--- a/src/yarn/exec.test.ts
+++ b/src/yarn/exec.test.ts
@@ -1,0 +1,17 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  exec: jest.fn(),
+}));
+
+it("should execute a Yarn command", async () => {
+  const { exec } = await import("@actions/exec");
+  const { execYarn } = await import("./exec.js");
+
+  await execYarn(["do", "something"]);
+
+  expect(exec).toHaveBeenCalledTimes(1);
+  expect(exec).toHaveBeenCalledWith("corepack", ["yarn", "do", "something"], {
+    silent: true,
+  });
+});

--- a/src/yarn/exec.test.ts
+++ b/src/yarn/exec.test.ts
@@ -8,10 +8,14 @@ it("should execute a Yarn command", async () => {
   const { exec } = await import("@actions/exec");
   const { execYarn } = await import("./exec.js");
 
-  await execYarn(["do", "something"]);
+  const callback = () => {};
+  await execYarn(["do", "something"], callback);
 
   expect(exec).toHaveBeenCalledTimes(1);
   expect(exec).toHaveBeenCalledWith("corepack", ["yarn", "do", "something"], {
     silent: true,
+    listeners: {
+      stdline: callback,
+    },
   });
 });

--- a/src/yarn/exec.ts
+++ b/src/yarn/exec.ts
@@ -1,0 +1,10 @@
+import { exec } from "@actions/exec";
+
+/**
+ * Execute a Yarn command with the given arguments.
+ *
+ * @param args - The arguments of the Yarn command.
+ */
+export async function execYarn(args?: string[]): Promise<void> {
+  await exec("corepack", ["yarn", ...args], { silent: true });
+}

--- a/src/yarn/exec.ts
+++ b/src/yarn/exec.ts
@@ -3,8 +3,20 @@ import { exec } from "@actions/exec";
 /**
  * Execute a Yarn command with the given arguments.
  *
+ * This function executes the Yarn command silently, without outputting anything to the standard output.
+ * Optionally, a callback can be provided to read the output from the command.
+ *
  * @param args - The arguments of the Yarn command.
+ * @param stdlineCallback - A callback to be called when receiving a line from the standard output.
  */
-export async function execYarn(args?: string[]): Promise<void> {
-  await exec("corepack", ["yarn", ...args], { silent: true });
+export async function execYarn(
+  args?: string[],
+  stdlineCallback?: (data: string) => void,
+): Promise<void> {
+  await exec("corepack", ["yarn", ...args], {
+    silent: true,
+    listeners: {
+      stdline: stdlineCallback,
+    },
+  });
 }

--- a/src/yarn/install.test.ts
+++ b/src/yarn/install.test.ts
@@ -6,8 +6,8 @@ jest.unstable_mockModule("@actions/core", () => ({
   warning: jest.fn(),
 }));
 
-jest.unstable_mockModule("@actions/exec", () => ({
-  exec: jest.fn(),
+jest.unstable_mockModule("./exec.ts", () => ({
+  execYarn: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -78,24 +78,22 @@ describe("print Yarn install package output", () => {
 
 it("should install package using Yarn", async () => {
   const core = await import("@actions/core");
-  const { exec } = await import("@actions/exec");
+  const { execYarn } = await import("./exec.js");
   const { yarnInstall } = await import("./install.js");
 
-  jest.mocked(exec).mockImplementation(async (commandLine, args, options) => {
-    options?.listeners?.stdline(
+  jest.mocked(execYarn).mockImplementation(async (args, callback) => {
+    callback(
       `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
     );
-    return 0;
   });
 
   await yarnInstall();
 
-  expect(exec).toHaveBeenCalledTimes(1);
+  expect(execYarn).toHaveBeenCalledTimes(1);
 
-  const execCall = jest.mocked(exec).mock.calls[0];
-  expect(execCall).toHaveLength(3);
-  expect(execCall[0]).toBe("corepack");
-  expect(execCall[1]).toEqual(["yarn", "install", "--json"]);
+  const execYarnCall = jest.mocked(execYarn).mock.calls[0];
+  expect(execYarnCall).toHaveLength(2);
+  expect(execYarnCall[0]).toEqual(["install", "--json"]);
 
   expect(core.info).toHaveBeenCalledTimes(1);
   expect(core.info).toHaveBeenCalledWith("YN0000: └ Completed");

--- a/src/yarn/install.ts
+++ b/src/yarn/install.ts
@@ -1,5 +1,5 @@
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
+import { execYarn } from "./exec.js";
 
 export interface YarnInstallOutput {
   type: "info" | "warning" | "error";
@@ -23,13 +23,8 @@ export function printYarnInstallOutput(output: YarnInstallOutput): void {
 }
 
 export async function yarnInstall(): Promise<void> {
-  await exec("corepack", ["yarn", "install", "--json"], {
-    silent: true,
-    listeners: {
-      stdline: (data) => {
-        const output = JSON.parse(data) as YarnInstallOutput;
-        printYarnInstallOutput(output);
-      },
-    },
+  await execYarn(["install", "--json"], (data) => {
+    const output = JSON.parse(data) as YarnInstallOutput;
+    printYarnInstallOutput(output);
   });
 }


### PR DESCRIPTION
This pull request resolves #191.

TODO:
- [ ] utilize `execYarn` in other functions.