### PR TITLE
Add Option for Independent Yarn Version Retrieval

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79504,7 +79504,7 @@ async function getCacheKey() {
     let cacheKey = `setup-yarn-action-${node_os__WEBPACK_IMPORTED_MODULE_2___default().type()}`;
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Getting Yarn version...");
     try {
-        const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)();
+        const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .getYarnVersion */ .Vh)({ corepack: true });
         cacheKey += `-${version}`;
     }
     catch (err) {
@@ -79743,8 +79743,16 @@ async function yarnInstall() {
 
 ;// CONCATENATED MODULE: ./src/yarn/version.ts
 
-async function getYarnVersion() {
-    const res = await (0,exec.getExecOutput)("corepack", ["yarn", "--version"], {
+/**
+ * Get the current Yarn version.
+ *
+ * @param options.corepack - Whether to get the current Yarn version using Corepack or not.
+ * @returns A promise resolving to the current Yarn version.
+ */
+async function getYarnVersion(options) {
+    const commandLine = options?.corepack ? "corepack" : "yarn";
+    const args = options?.corepack ? ["yarn", "--version"] : ["--version"];
+    const res = await (0,exec.getExecOutput)(commandLine, args, {
         silent: true,
     });
     return res.stdout.trim();

--- a/dist/index.js
+++ b/dist/index.js
@@ -79492,7 +79492,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var node_fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(node_fs__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(612);
 /* harmony import */ var node_os__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(node_os__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1913);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1750);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([hasha__WEBPACK_IMPORTED_MODULE_4__]);
 hasha__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 
@@ -79605,7 +79605,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(4278);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _cache_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7907);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1913);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1750);
 /* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(4885);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_cache_js__WEBPACK_IMPORTED_MODULE_2__]);
 _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
@@ -79697,7 +79697,7 @@ __webpack_async_result__();
 
 /***/ }),
 
-/***/ 1913:
+/***/ 1750:
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -79705,7 +79705,7 @@ __webpack_async_result__();
 __nccwpck_require__.d(__webpack_exports__, {
   "Wd": () => (/* binding */ enableYarn),
   "io": () => (/* binding */ getYarnConfig),
-  "Vh": () => (/* binding */ getYarnVersion),
+  "Vh": () => (/* reexport */ getYarnVersion),
   "Or": () => (/* reexport */ yarnInstall)
 });
 
@@ -79741,7 +79741,17 @@ async function yarnInstall() {
     });
 }
 
+;// CONCATENATED MODULE: ./src/yarn/version.ts
+
+async function getYarnVersion() {
+    const res = await (0,exec.getExecOutput)("corepack", ["yarn", "--version"], {
+        silent: true,
+    });
+    return res.stdout.trim();
+}
+
 ;// CONCATENATED MODULE: ./src/yarn/index.ts
+
 
 
 async function enableYarn() {
@@ -79752,12 +79762,6 @@ async function getYarnConfig(name) {
         silent: true,
     });
     return JSON.parse(res.stdout).effective;
-}
-async function getYarnVersion() {
-    const res = await (0,exec.getExecOutput)("corepack", ["yarn", "--version"], {
-        silent: true,
-    });
-    return res.stdout.trim();
 }
 
 

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -59,7 +59,10 @@ describe("get cache key", () => {
       return false;
     });
 
-    jest.mocked(getYarnVersion).mockResolvedValue("1.2.3");
+    jest.mocked(getYarnVersion).mockImplementation(async (options) => {
+      if (options.corepack) return "1.2.3";
+      throw new Error("Unable to get Yarn version");
+    });
   });
 
   it("should failed to get Yarn version", async () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,7 +9,7 @@ export async function getCacheKey(): Promise<string> {
 
   core.info("Getting Yarn version...");
   try {
-    const version = await getYarnVersion();
+    const version = await getYarnVersion({ corepack: true });
     cacheKey += `-${version}`;
   } catch (err) {
     core.setFailed(`Failed to get Yarn version: ${err.message}`);

--- a/src/yarn/index.test.ts
+++ b/src/yarn/index.test.ts
@@ -44,27 +44,3 @@ it("should get Yarn config", async () => {
 
   expect(value).toEqual("/.yarn/berry");
 });
-
-it("should get Yarn version", async () => {
-  const { getExecOutput } = await import("@actions/exec");
-  const { getYarnVersion } = await import("./index.js");
-
-  jest.mocked(getExecOutput).mockResolvedValueOnce({
-    exitCode: 0,
-    stdout: "1.2.3",
-    stderr: "",
-  });
-
-  const version = await getYarnVersion();
-
-  expect(getExecOutput).toHaveBeenCalledTimes(1);
-  expect(getExecOutput).toHaveBeenCalledWith(
-    "corepack",
-    ["yarn", "--version"],
-    {
-      silent: true,
-    },
-  );
-
-  expect(version).toEqual("1.2.3");
-});

--- a/src/yarn/index.ts
+++ b/src/yarn/index.ts
@@ -1,5 +1,6 @@
 import { exec, getExecOutput } from "@actions/exec";
 export { yarnInstall } from "./install.js";
+export { getYarnVersion } from "./version.js";
 
 export async function enableYarn(): Promise<void> {
   await exec("corepack", ["enable", "yarn"], { silent: true });
@@ -14,11 +15,4 @@ export async function getYarnConfig(name: string): Promise<string> {
     },
   );
   return JSON.parse(res.stdout).effective;
-}
-
-export async function getYarnVersion() {
-  const res = await getExecOutput("corepack", ["yarn", "--version"], {
-    silent: true,
-  });
-  return res.stdout.trim();
 }

--- a/src/yarn/version.test.ts
+++ b/src/yarn/version.test.ts
@@ -4,26 +4,46 @@ jest.unstable_mockModule("@actions/exec", () => ({
   getExecOutput: jest.fn(),
 }));
 
-it("should get Yarn version", async () => {
-  const { getExecOutput } = await import("@actions/exec");
-  const { getYarnVersion } = await import("./version.js");
+describe("get Yarn version", () => {
+  beforeEach(async () => {
+    const { getExecOutput } = await import("@actions/exec");
 
-  jest.mocked(getExecOutput).mockReset().mockResolvedValueOnce({
-    exitCode: 0,
-    stdout: "1.2.3",
-    stderr: "",
+    jest.mocked(getExecOutput).mockReset().mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "1.2.3",
+      stderr: "",
+    });
   });
 
-  const version = await getYarnVersion();
+  it("should get Yarn version", async () => {
+    const { getExecOutput } = await import("@actions/exec");
+    const { getYarnVersion } = await import("./version.js");
 
-  expect(getExecOutput).toHaveBeenCalledTimes(1);
-  expect(getExecOutput).toHaveBeenCalledWith(
-    "corepack",
-    ["yarn", "--version"],
-    {
+    const version = await getYarnVersion();
+
+    expect(getExecOutput).toHaveBeenCalledTimes(1);
+    expect(getExecOutput).toHaveBeenCalledWith("yarn", ["--version"], {
       silent: true,
-    },
-  );
+    });
 
-  expect(version).toEqual("1.2.3");
+    expect(version).toEqual("1.2.3");
+  });
+
+  it("should get Yarn version using Corepack", async () => {
+    const { getExecOutput } = await import("@actions/exec");
+    const { getYarnVersion } = await import("./version.js");
+
+    const version = await getYarnVersion({ corepack: true });
+
+    expect(getExecOutput).toHaveBeenCalledTimes(1);
+    expect(getExecOutput).toHaveBeenCalledWith(
+      "corepack",
+      ["yarn", "--version"],
+      {
+        silent: true,
+      },
+    );
+
+    expect(version).toEqual("1.2.3");
+  });
 });

--- a/src/yarn/version.test.ts
+++ b/src/yarn/version.test.ts
@@ -1,0 +1,29 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  getExecOutput: jest.fn(),
+}));
+
+it("should get Yarn version", async () => {
+  const { getExecOutput } = await import("@actions/exec");
+  const { getYarnVersion } = await import("./version.js");
+
+  jest.mocked(getExecOutput).mockReset().mockResolvedValueOnce({
+    exitCode: 0,
+    stdout: "1.2.3",
+    stderr: "",
+  });
+
+  const version = await getYarnVersion();
+
+  expect(getExecOutput).toHaveBeenCalledTimes(1);
+  expect(getExecOutput).toHaveBeenCalledWith(
+    "corepack",
+    ["yarn", "--version"],
+    {
+      silent: true,
+    },
+  );
+
+  expect(version).toEqual("1.2.3");
+});

--- a/src/yarn/version.ts
+++ b/src/yarn/version.ts
@@ -1,0 +1,8 @@
+import { getExecOutput } from "@actions/exec";
+
+export async function getYarnVersion() {
+  const res = await getExecOutput("corepack", ["yarn", "--version"], {
+    silent: true,
+  });
+  return res.stdout.trim();
+}

--- a/src/yarn/version.ts
+++ b/src/yarn/version.ts
@@ -1,7 +1,17 @@
 import { getExecOutput } from "@actions/exec";
 
-export async function getYarnVersion() {
-  const res = await getExecOutput("corepack", ["yarn", "--version"], {
+/**
+ * Get the current Yarn version.
+ *
+ * @param options.corepack - Whether to get the current Yarn version using Corepack or not.
+ * @returns A promise resolving to the current Yarn version.
+ */
+export async function getYarnVersion(options?: {
+  corepack: boolean;
+}): Promise<string> {
+  const commandLine = options?.corepack ? "corepack" : "yarn";
+  const args = options?.corepack ? ["yarn", "--version"] : ["--version"];
+  const res = await getExecOutput(commandLine, args, {
     silent: true,
   });
   return res.stdout.trim();


### PR DESCRIPTION
This pull request resolves #193 by implementing the following updates:
- Relocates the `getYarnVersion` function from `src/yarn/index.ts` to `src/yarn/version.ts`.
- Introduces an `options.corepack` parameter in the `getYarnVersion` function to specify whether Corepack should be used for retrieving the Yarn version.