### PR TITLE
Organize Corepack Functions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79561,6 +79561,7 @@ __webpack_async_result__();
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "I": () => (/* binding */ corepackAssertYarnVersion),
 /* harmony export */   "_": () => (/* binding */ corepackEnableYarn)
 /* harmony export */ });
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
@@ -79569,21 +79570,30 @@ __webpack_async_result__();
 
 
 /**
+ * Assert Yarn version enabled by Corepack.
+ *
+ * This function asserts whether Yarn is updated to the correct version set by Corepack.
+ * It asserts the Yarn version by checking if the `yarn` command is using the same version as the `corepack yarn` command.
+ *
+ * @returns A promise that resolves to nothing.
+ * @throws If the `yarn` command is using a different version of Yarn.
+ */
+async function corepackAssertYarnVersion() {
+    const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)();
+    const corepackVersion = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)({ corepack: true });
+    if (version !== corepackVersion) {
+        throw new Error(`The \`yarn\` command is using a different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``);
+    }
+}
+/**
  * Enable Yarn using Corepack.
  *
  * This function makes Yarn available in the environment by using Corepack.
- * It also checks if the `yarn` command is updated to the correct version set by Corepack.
  *
  * @returns A promise that resolves to nothing.
  */
 async function corepackEnableYarn() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"], { silent: true });
-    // Check if the `yarn` command is using the same version as the `corepack yarn` command.
-    const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)();
-    const corepackVersion = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)({ corepack: true });
-    if (version != corepackVersion) {
-        throw new Error(`The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``);
-    }
 }
 
 
@@ -79654,6 +79664,7 @@ async function main() {
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
     try {
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackEnableYarn */ ._)();
+        await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackAssertYarnVersion */ .I)();
     }
     catch (err) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to enable Yarn: ${err.message}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -79557,6 +79557,38 @@ __webpack_async_result__();
 
 /***/ }),
 
+/***/ 3396:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "_": () => (/* binding */ corepackEnableYarn)
+/* harmony export */ });
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(1750);
+
+
+/**
+ * Enable Yarn using Corepack.
+ *
+ * This function makes Yarn available in the environment by using Corepack.
+ * It also checks if the `yarn` command is updated to the correct version set by Corepack.
+ *
+ * @returns A promise that resolves to nothing.
+ */
+async function corepackEnableYarn() {
+    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"], { silent: true });
+    // Check if the `yarn` command is using the same version as the `corepack yarn` command.
+    const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)();
+    const corepackVersion = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_1__/* .getYarnVersion */ .Vh)({ corepack: true });
+    if (version != corepackVersion) {
+        throw new Error(`The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``);
+    }
+}
+
+
+/***/ }),
+
 /***/ 2158:
 /***/ ((module, __unused_webpack___webpack_exports__, __nccwpck_require__) => {
 
@@ -79605,8 +79637,9 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(4278);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _cache_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7907);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(1750);
-/* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(4885);
+/* harmony import */ var _corepack_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(3396);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(1750);
+/* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(4885);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_cache_js__WEBPACK_IMPORTED_MODULE_2__]);
 _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 
@@ -79614,12 +79647,13 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 
 
+
 async function main() {
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Getting action inputs...");
-    const inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_4__/* .getInputs */ .G)();
+    const inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_5__/* .getInputs */ .G)();
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
     try {
-        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
+        await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackEnableYarn */ ._)();
     }
     catch (err) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to enable Yarn: ${err.message}`);
@@ -79670,7 +79704,7 @@ async function main() {
     }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Installing dependencies");
     try {
-        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .yarnInstall */ .Or)();
+        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_4__/* .yarnInstall */ .Or)();
     }
     catch (err) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.endGroup();
@@ -79703,7 +79737,6 @@ __webpack_async_result__();
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
-  "Wd": () => (/* binding */ enableYarn),
   "io": () => (/* binding */ getYarnConfig),
   "Vh": () => (/* reexport */ getYarnVersion),
   "Or": () => (/* reexport */ yarnInstall)
@@ -79711,23 +79744,6 @@ __nccwpck_require__.d(__webpack_exports__, {
 
 // EXTERNAL MODULE: ./.yarn/cache/@actions-exec-npm-1.1.1-90973d2f96-4a09f6bdbe.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(8434);
-;// CONCATENATED MODULE: ./src/yarn/version.ts
-
-/**
- * Get the current Yarn version.
- *
- * @param options.corepack - Whether to get the current Yarn version using Corepack or not.
- * @returns A promise resolving to the current Yarn version.
- */
-async function getYarnVersion(options) {
-    const commandLine = options?.corepack ? "corepack" : "yarn";
-    const args = options?.corepack ? ["yarn", "--version"] : ["--version"];
-    const res = await (0,exec.getExecOutput)(commandLine, args, {
-        silent: true,
-    });
-    return res.stdout.trim();
-}
-
 // EXTERNAL MODULE: ./.yarn/cache/@actions-core-npm-1.10.1-3cb1000b4d-7a61446697.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(4278);
 ;// CONCATENATED MODULE: ./src/yarn/install.ts
@@ -79758,20 +79774,27 @@ async function yarnInstall() {
     });
 }
 
+;// CONCATENATED MODULE: ./src/yarn/version.ts
+
+/**
+ * Get the current Yarn version.
+ *
+ * @param options.corepack - Whether to get the current Yarn version using Corepack or not.
+ * @returns A promise resolving to the current Yarn version.
+ */
+async function getYarnVersion(options) {
+    const commandLine = options?.corepack ? "corepack" : "yarn";
+    const args = options?.corepack ? ["yarn", "--version"] : ["--version"];
+    const res = await (0,exec.getExecOutput)(commandLine, args, {
+        silent: true,
+    });
+    return res.stdout.trim();
+}
+
 ;// CONCATENATED MODULE: ./src/yarn/index.ts
 
 
 
-
-async function enableYarn() {
-    await (0,exec.exec)("corepack", ["enable", "yarn"], { silent: true });
-    // Check if the `yarn` command is using the same version as the `corepack yarn` command.
-    const version = await getYarnVersion();
-    const corepackVersion = await getYarnVersion({ corepack: true });
-    if (version != corepackVersion) {
-        throw new Error(`The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``);
-    }
-}
 async function getYarnConfig(name) {
     const res = await (0,exec.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
         silent: true,

--- a/src/corepack.test.ts
+++ b/src/corepack.test.ts
@@ -1,0 +1,47 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  exec: jest.fn(),
+}));
+
+jest.unstable_mockModule("./yarn/index.js", () => ({
+  getYarnVersion: jest.fn(),
+}));
+
+describe("enable Yarn using Corepack", () => {
+  beforeEach(async () => {
+    const { getYarnVersion } = await import("./yarn/index.js");
+
+    jest.mocked(getYarnVersion).mockResolvedValue("1.2.3");
+  });
+
+  it("should enable Yarn", async () => {
+    const { exec } = await import("@actions/exec");
+    const { corepackEnableYarn } = await import("./corepack.js");
+
+    await expect(corepackEnableYarn()).resolves.toBeUndefined();
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"], {
+      silent: true,
+    });
+  });
+
+  describe("with different Yarn versions", () => {
+    beforeEach(async () => {
+      const { getYarnVersion } = await import("./yarn/index.js");
+
+      jest.mocked(getYarnVersion).mockImplementation(async (options) => {
+        return options?.corepack ? "1.2.3" : "1.2.4";
+      });
+    });
+
+    it("should failed to enable Yarn", async () => {
+      const { corepackEnableYarn } = await import("./corepack.js");
+
+      await expect(corepackEnableYarn()).rejects.toThrow(
+        "The `yarn` command is using different version of Yarn, expected `1.2.3` but got `1.2.4`",
+      );
+    });
+  });
+});

--- a/src/corepack.test.ts
+++ b/src/corepack.test.ts
@@ -8,13 +8,31 @@ jest.unstable_mockModule("./yarn/index.js", () => ({
   getYarnVersion: jest.fn(),
 }));
 
-describe("enable Yarn using Corepack", () => {
-  beforeEach(async () => {
+describe("assert Yarn version enabled by Corepack", () => {
+  it("should not throw an error if Yarn versions are the same", async () => {
     const { getYarnVersion } = await import("./yarn/index.js");
+    const { corepackAssertYarnVersion } = await import("./corepack.js");
 
     jest.mocked(getYarnVersion).mockResolvedValue("1.2.3");
+
+    await expect(corepackAssertYarnVersion()).resolves.toBeUndefined();
   });
 
+  it("should throw an error if Yarn versions are different", async () => {
+    const { getYarnVersion } = await import("./yarn/index.js");
+    const { corepackAssertYarnVersion } = await import("./corepack.js");
+
+    jest.mocked(getYarnVersion).mockImplementation(async (options) => {
+      return options?.corepack ? "1.2.3" : "1.2.4";
+    });
+
+    await expect(corepackAssertYarnVersion()).rejects.toThrow(
+      "The `yarn` command is using a different version of Yarn, expected `1.2.3` but got `1.2.4`",
+    );
+  });
+});
+
+describe("enable Yarn using Corepack", () => {
   it("should enable Yarn", async () => {
     const { exec } = await import("@actions/exec");
     const { corepackEnableYarn } = await import("./corepack.js");
@@ -24,24 +42,6 @@ describe("enable Yarn using Corepack", () => {
     expect(exec).toHaveBeenCalledTimes(1);
     expect(exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"], {
       silent: true,
-    });
-  });
-
-  describe("with different Yarn versions", () => {
-    beforeEach(async () => {
-      const { getYarnVersion } = await import("./yarn/index.js");
-
-      jest.mocked(getYarnVersion).mockImplementation(async (options) => {
-        return options?.corepack ? "1.2.3" : "1.2.4";
-      });
-    });
-
-    it("should failed to enable Yarn", async () => {
-      const { corepackEnableYarn } = await import("./corepack.js");
-
-      await expect(corepackEnableYarn()).rejects.toThrow(
-        "The `yarn` command is using different version of Yarn, expected `1.2.3` but got `1.2.4`",
-      );
     });
   });
 });

--- a/src/corepack.ts
+++ b/src/corepack.ts
@@ -2,22 +2,31 @@ import { exec } from "@actions/exec";
 import { getYarnVersion } from "./yarn/index.js";
 
 /**
+ * Assert Yarn version enabled by Corepack.
+ *
+ * This function asserts whether Yarn is updated to the correct version set by Corepack.
+ * It asserts the Yarn version by checking if the `yarn` command is using the same version as the `corepack yarn` command.
+ *
+ * @returns A promise that resolves to nothing.
+ * @throws If the `yarn` command is using a different version of Yarn.
+ */
+export async function corepackAssertYarnVersion(): Promise<void> {
+  const version = await getYarnVersion();
+  const corepackVersion = await getYarnVersion({ corepack: true });
+  if (version !== corepackVersion) {
+    throw new Error(
+      `The \`yarn\` command is using a different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``,
+    );
+  }
+}
+
+/**
  * Enable Yarn using Corepack.
  *
  * This function makes Yarn available in the environment by using Corepack.
- * It also checks if the `yarn` command is updated to the correct version set by Corepack.
  *
  * @returns A promise that resolves to nothing.
  */
 export async function corepackEnableYarn(): Promise<void> {
   await exec("corepack", ["enable", "yarn"], { silent: true });
-
-  // Check if the `yarn` command is using the same version as the `corepack yarn` command.
-  const version = await getYarnVersion();
-  const corepackVersion = await getYarnVersion({ corepack: true });
-  if (version != corepackVersion) {
-    throw new Error(
-      `The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``,
-    );
-  }
 }

--- a/src/corepack.ts
+++ b/src/corepack.ts
@@ -1,0 +1,23 @@
+import { exec } from "@actions/exec";
+import { getYarnVersion } from "./yarn/index.js";
+
+/**
+ * Enable Yarn using Corepack.
+ *
+ * This function makes Yarn available in the environment by using Corepack.
+ * It also checks if the `yarn` command is updated to the correct version set by Corepack.
+ *
+ * @returns A promise that resolves to nothing.
+ */
+export async function corepackEnableYarn(): Promise<void> {
+  await exec("corepack", ["enable", "yarn"], { silent: true });
+
+  // Check if the `yarn` command is using the same version as the `corepack yarn` command.
+  const version = await getYarnVersion();
+  const corepackVersion = await getYarnVersion({ corepack: true });
+  if (version != corepackVersion) {
+    throw new Error(
+      `The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``,
+    );
+  }
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -23,6 +23,7 @@ jest.unstable_mockModule("./cache.js", () => ({
 }));
 
 jest.unstable_mockModule("./corepack.js", () => ({
+  corepackAssertYarnVersion: jest.fn(),
   corepackEnableYarn: jest.fn(),
 }));
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -14,13 +14,16 @@ jest.unstable_mockModule("@actions/core", () => ({
 }));
 
 jest.unstable_mockModule("./yarn/index.js", () => ({
-  enableYarn: jest.fn(),
   yarnInstall: jest.fn(),
 }));
 
 jest.unstable_mockModule("./cache.js", () => ({
   getCacheKey: jest.fn(),
   getCachePaths: jest.fn(),
+}));
+
+jest.unstable_mockModule("./corepack.js", () => ({
+  corepackEnableYarn: jest.fn(),
 }));
 
 jest.unstable_mockModule("./inputs.js", () => ({
@@ -38,8 +41,9 @@ describe("install Yarn dependencies", () => {
   beforeEach(async () => {
     const { restoreCache, saveCache } = await import("@actions/cache");
     const core = await import("@actions/core");
-    const { enableYarn, yarnInstall } = await import("./yarn/index.js");
+    const { yarnInstall } = await import("./yarn/index.js");
     const { getCacheKey, getCachePaths } = await import("./cache.js");
+    const { corepackEnableYarn } = await import("./corepack.js");
     const { getInputs } = await import("./inputs.js");
 
     failed = false;
@@ -85,7 +89,7 @@ describe("install Yarn dependencies", () => {
       logs.push(message);
     });
 
-    jest.mocked(enableYarn).mockImplementation(async () => {
+    jest.mocked(corepackEnableYarn).mockImplementation(async () => {
       core.info("Yarn enabled");
     });
 
@@ -100,10 +104,10 @@ describe("install Yarn dependencies", () => {
   });
 
   it("should failed to enable Yarn", async () => {
-    const { enableYarn } = await import("./yarn/index.js");
+    const { corepackEnableYarn } = await import("./corepack.js");
     const { main } = await import("./main.js");
 
-    jest.mocked(enableYarn).mockRejectedValue(new Error("some error"));
+    jest.mocked(corepackEnableYarn).mockRejectedValue(new Error("some error"));
 
     await main();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
-import { corepackEnableYarn } from "./corepack.js";
+import { corepackAssertYarnVersion, corepackEnableYarn } from "./corepack.js";
 import { yarnInstall } from "./yarn/index.js";
 import { getInputs } from "./inputs.js";
 
@@ -12,6 +12,7 @@ export async function main(): Promise<void> {
   core.info("Enabling Yarn...");
   try {
     await corepackEnableYarn();
+    await corepackAssertYarnVersion();
   } catch (err) {
     core.setFailed(`Failed to enable Yarn: ${err.message}`);
     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
-import { enableYarn, yarnInstall } from "./yarn/index.js";
+import { corepackEnableYarn } from "./corepack.js";
+import { yarnInstall } from "./yarn/index.js";
 import { getInputs } from "./inputs.js";
 
 export async function main(): Promise<void> {
@@ -10,7 +11,7 @@ export async function main(): Promise<void> {
 
   core.info("Enabling Yarn...");
   try {
-    await enableYarn();
+    await corepackEnableYarn();
   } catch (err) {
     core.setFailed(`Failed to enable Yarn: ${err.message}`);
     return;

--- a/src/yarn/index.test.ts
+++ b/src/yarn/index.test.ts
@@ -1,55 +1,9 @@
 import { jest } from "@jest/globals";
 
 jest.unstable_mockModule("@actions/exec", () => ({
-  exec: jest.fn(),
+  ...jest.requireActual<object>("@actions/exec"),
   getExecOutput: jest.fn(),
 }));
-
-jest.unstable_mockModule("./version.js", () => ({
-  getYarnVersion: jest.fn(),
-}));
-
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
-describe("enable Yarn", () => {
-  beforeEach(async () => {
-    const { getYarnVersion } = await import("./version.js");
-
-    jest.mocked(getYarnVersion).mockResolvedValue("1.2.3");
-  });
-
-  it("should enable Yarn", async () => {
-    const { exec } = await import("@actions/exec");
-    const { enableYarn } = await import("./index.js");
-
-    await expect(enableYarn()).resolves.toBeUndefined();
-
-    expect(exec).toHaveBeenCalledTimes(1);
-    expect(exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"], {
-      silent: true,
-    });
-  });
-
-  describe("with different Yarn versions", () => {
-    beforeEach(async () => {
-      const { getYarnVersion } = await import("./version.js");
-
-      jest.mocked(getYarnVersion).mockImplementation(async (options) => {
-        return options?.corepack ? "1.2.3" : "1.2.4";
-      });
-    });
-
-    it("should failed to enable Yarn", async () => {
-      const { enableYarn } = await import("./index.js");
-
-      await expect(enableYarn()).rejects.toThrow(
-        "The `yarn` command is using different version of Yarn, expected `1.2.3` but got `1.2.4`",
-      );
-    });
-  });
-});
 
 it("should get Yarn config", async () => {
   const { getExecOutput } = await import("@actions/exec");

--- a/src/yarn/index.ts
+++ b/src/yarn/index.ts
@@ -1,20 +1,6 @@
-import { exec, getExecOutput } from "@actions/exec";
-import { getYarnVersion } from "./version.js";
+import { getExecOutput } from "@actions/exec";
 export { yarnInstall } from "./install.js";
 export { getYarnVersion } from "./version.js";
-
-export async function enableYarn(): Promise<void> {
-  await exec("corepack", ["enable", "yarn"], { silent: true });
-
-  // Check if the `yarn` command is using the same version as the `corepack yarn` command.
-  const version = await getYarnVersion();
-  const corepackVersion = await getYarnVersion({ corepack: true });
-  if (version != corepackVersion) {
-    throw new Error(
-      `The \`yarn\` command is using different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``,
-    );
-  }
-}
 
 export async function getYarnConfig(name: string): Promise<string> {
   const res = await getExecOutput(


### PR DESCRIPTION
This pull request resolves #197 by separating the `enableYarn` function into `corepackEnableYarn` and `corepackAssertYarnVersion` functions and moving them to the `src/corepack.ts` file.