### PR TITLE
Run Yarn Command Without Corepack

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,5 +22,5 @@ jobs:
 
       - name: Build Package
         run: |
-          corepack yarn build
+          yarn build
           git diff --exit-code --text HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Check Format
         run: |
-          corepack yarn format
+          yarn format
           git diff --exit-code --text HEAD
 
       - name: Check Lint
-        run: corepack yarn lint
+        run: yarn lint
 
   test-package:
     name: Test Package
@@ -44,7 +44,7 @@ jobs:
         uses: threeal/setup-yarn-action@v1.0.0
 
       - name: Test Package
-        run: corepack yarn test
+        run: yarn test
 
   test-action:
     name: Test Action
@@ -72,7 +72,7 @@ jobs:
         uses: ./setup-yarn-action
 
       - name: Build Package
-        run: corepack yarn pack
+        run: yarn pack
 
   test-action-without-cache:
     name: Test Action Without Cache
@@ -102,7 +102,7 @@ jobs:
           cache: false
 
       - name: Build Package
-        run: corepack yarn pack
+        run: yarn pack
 
   test-action-with-yarn-local-cache:
     name: Test Action With Yarn Local Cache
@@ -125,10 +125,10 @@ jobs:
       - name: Disable Yarn Global Cache
         run: |
           corepack enable yarn
-          corepack yarn config set enableGlobalCache false
+          yarn config set enableGlobalCache false
 
       - name: Setup Yarn
         uses: ./setup-yarn-action
 
       - name: Build Package
-        run: corepack yarn pack
+        run: yarn pack

--- a/dist/index.js
+++ b/dist/index.js
@@ -79796,7 +79796,7 @@ function printYarnInstallOutput(output) {
     }
 }
 async function yarnInstall() {
-    await (0,exec.exec)("corepack", ["yarn", "install", "--json"], {
+    await (0,exec.exec)("yarn", ["install", "--json"], {
         silent: true,
         listeners: {
             stdline: (data) => {
@@ -79829,7 +79829,7 @@ async function getYarnVersion(options) {
 
 
 async function getYarnConfig(name) {
-    const res = await (0,exec.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
+    const res = await (0,exec.getExecOutput)("yarn", ["config", name, "--json"], {
         silent: true,
     });
     return JSON.parse(res.stdout).effective;

--- a/src/yarn/index.test.ts
+++ b/src/yarn/index.test.ts
@@ -19,8 +19,8 @@ it("should get Yarn config", async () => {
 
   expect(getExecOutput).toHaveBeenCalledTimes(1);
   expect(getExecOutput).toHaveBeenCalledWith(
-    "corepack",
-    ["yarn", "config", "globalFolder", "--json"],
+    "yarn",
+    ["config", "globalFolder", "--json"],
     {
       silent: true,
     },

--- a/src/yarn/index.ts
+++ b/src/yarn/index.ts
@@ -3,12 +3,8 @@ export { yarnInstall } from "./install.js";
 export { getYarnVersion } from "./version.js";
 
 export async function getYarnConfig(name: string): Promise<string> {
-  const res = await getExecOutput(
-    "corepack",
-    ["yarn", "config", name, "--json"],
-    {
-      silent: true,
-    },
-  );
+  const res = await getExecOutput("yarn", ["config", name, "--json"], {
+    silent: true,
+  });
   return JSON.parse(res.stdout).effective;
 }

--- a/src/yarn/install.test.ts
+++ b/src/yarn/install.test.ts
@@ -94,8 +94,8 @@ it("should install package using Yarn", async () => {
 
   const execCall = jest.mocked(exec).mock.calls[0];
   expect(execCall).toHaveLength(3);
-  expect(execCall[0]).toBe("corepack");
-  expect(execCall[1]).toEqual(["yarn", "install", "--json"]);
+  expect(execCall[0]).toBe("yarn");
+  expect(execCall[1]).toEqual(["install", "--json"]);
 
   expect(core.info).toHaveBeenCalledTimes(1);
   expect(core.info).toHaveBeenCalledWith("YN0000: └ Completed");

--- a/src/yarn/install.ts
+++ b/src/yarn/install.ts
@@ -23,7 +23,7 @@ export function printYarnInstallOutput(output: YarnInstallOutput): void {
 }
 
 export async function yarnInstall(): Promise<void> {
-  await exec("corepack", ["yarn", "install", "--json"], {
+  await exec("yarn", ["install", "--json"], {
     silent: true,
     listeners: {
       stdline: (data) => {


### PR DESCRIPTION
This pull request resolves #201 by running the Yarn command without Corepack in Yarn functions and CI workflows.