### PR TITLE
Add Function for Setting Yarn Version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79775,8 +79775,10 @@ __nccwpck_require__.d(__webpack_exports__, {
   "Or": () => (/* reexport */ yarnInstall)
 });
 
+// UNUSED EXPORTS: setYarnVersion
+
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
-var exec = __nccwpck_require__(4926);
+var lib_exec = __nccwpck_require__(4926);
 ;// CONCATENATED MODULE: ./src/yarn/config.ts
 
 /**
@@ -79786,7 +79788,7 @@ var exec = __nccwpck_require__(4926);
  * @returns A promise resolving to the value of the Yarn configuration.
  */
 async function getYarnConfig(name) {
-    const res = await (0,exec.getExecOutput)("yarn", ["config", name, "--json"], {
+    const res = await (0,lib_exec.getExecOutput)("yarn", ["config", name, "--json"], {
         silent: true,
     });
     return JSON.parse(res.stdout).effective;
@@ -79811,7 +79813,7 @@ function printYarnInstallOutput(output) {
     }
 }
 async function yarnInstall() {
-    await (0,exec.exec)("yarn", ["install", "--json"], {
+    await (0,lib_exec.exec)("yarn", ["install", "--json"], {
         silent: true,
         listeners: {
             stdline: (data) => {
@@ -79833,10 +79835,19 @@ async function yarnInstall() {
 async function getYarnVersion(options) {
     const commandLine = options?.corepack ? "corepack" : "yarn";
     const args = options?.corepack ? ["yarn", "--version"] : ["--version"];
-    const res = await (0,exec.getExecOutput)(commandLine, args, {
+    const res = await (0,lib_exec.getExecOutput)(commandLine, args, {
         silent: true,
     });
     return res.stdout.trim();
+}
+/**
+ * Set the Yarn version.
+ *
+ * @param version - The new Yarn version to set.
+ * @returns A promise that resolves to nothing.
+ */
+async function setYarnVersion(version) {
+    await exec("yarn", ["set", "version", version], { silent: true });
 }
 
 ;// CONCATENATED MODULE: ./src/yarn/index.ts

--- a/src/yarn/index.ts
+++ b/src/yarn/index.ts
@@ -1,3 +1,3 @@
 export { getYarnConfig } from "./config.js";
 export { yarnInstall } from "./install.js";
-export { getYarnVersion } from "./version.js";
+export { getYarnVersion, setYarnVersion } from "./version.js";

--- a/src/yarn/version.test.ts
+++ b/src/yarn/version.test.ts
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 import "jest-extended";
 
 jest.unstable_mockModule("@actions/exec", () => ({
+  exec: jest.fn(),
   getExecOutput: jest.fn(),
 }));
 
@@ -40,6 +41,30 @@ describe("get Yarn version", () => {
     expect(getExecOutput).toHaveBeenCalledExactlyOnceWith(
       "corepack",
       ["yarn", "--version"],
+      {
+        silent: true,
+      },
+    );
+  });
+});
+
+describe("set Yarn version", () => {
+  beforeEach(async () => {
+    const { exec } = await import("@actions/exec");
+
+    jest.mocked(exec).mockReset();
+  });
+
+  it("should set Yarn version", async () => {
+    const { exec } = await import("@actions/exec");
+    const { setYarnVersion } = await import("./version.js");
+
+    const prom = setYarnVersion("stable");
+    await expect(prom).resolves.toBeUndefined();
+
+    expect(exec).toHaveBeenCalledExactlyOnceWith(
+      "yarn",
+      ["set", "version", "stable"],
       {
         silent: true,
       },

--- a/src/yarn/version.ts
+++ b/src/yarn/version.ts
@@ -1,4 +1,4 @@
-import { getExecOutput } from "@actions/exec";
+import { exec, getExecOutput } from "@actions/exec";
 
 /**
  * Get the current Yarn version.
@@ -15,4 +15,14 @@ export async function getYarnVersion(options?: {
     silent: true,
   });
   return res.stdout.trim();
+}
+
+/**
+ * Set the Yarn version.
+ *
+ * @param version - The new Yarn version to set.
+ * @returns A promise that resolves to nothing.
+ */
+export async function setYarnVersion(version: string): Promise<void> {
+  await exec("yarn", ["set", "version", version], { silent: true });
 }


### PR DESCRIPTION
This pull request resolves #214 by adding a `setYarnVersion` function alongside its testing.