### PR TITLE
Utilize `.env.yarn` to Set `NODE_OPTIONS`

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.eslint*
 !.git*
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "ncc build src/index.ts",
     "format": "prettier --write --cache . !dist",
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules yarn jest"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/cache": "^3.2.4",
@@ -20,7 +20,6 @@
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
     "@vercel/ncc": "^0.38.1",
-    "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,19 +1925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: "npm:^7.0.1"
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 10c0/f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4296,7 +4284,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.1.0"
     "@typescript-eslint/parser": "npm:^7.1.0"
     "@vercel/ncc": "npm:^0.38.1"
-    cross-env: "npm:^7.0.3"
     eslint: "npm:^8.57.0"
     hasha: "npm:^6.0.0"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #220 by utilizing the `.env.yarn` file to set the `NODE_OPTIONS` environment variable. Additionally, it adjusts the `test` script accordingly and removes the [cross-env](https://www.npmjs.com/package/cross-env) package from the dependencies.