### PR TITLE
Catch Exception When Getting Action Inputs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79683,7 +79683,14 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 async function main() {
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Getting action inputs...");
-    const inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_5__/* .getInputs */ .G)();
+    let inputs;
+    try {
+        inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_5__/* .getInputs */ .G)();
+    }
+    catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(`Failed to get action inputs: ${err.message}`);
+        return;
+    }
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
     try {
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackEnableYarn */ ._)();

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,6 +1,6 @@
 import { getBooleanInput, getInput } from "@actions/core";
 
-interface Inputs {
+export interface Inputs {
   version: string;
   cache: boolean;
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -105,6 +105,23 @@ describe("install Yarn dependencies", () => {
     jest.mocked(getInputs).mockReturnValue({ version: "", cache: true });
   });
 
+  it("should failed to get action inputs", async () => {
+    const { getInputs } = await import("./inputs.js");
+    const { main } = await import("./main.js");
+
+    jest.mocked(getInputs).mockImplementation(() => {
+      throw new Error("some error");
+    });
+
+    await main();
+
+    expect(failed).toBe(true);
+    expect(logs).toStrictEqual([
+      "Getting action inputs...",
+      "Failed to get action inputs: some error",
+    ]);
+  });
+
   it("should failed to enable Yarn", async () => {
     const { corepackEnableYarn } = await import("./corepack.js");
     const { main } = await import("./main.js");

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,17 @@ import * as core from "@actions/core";
 import { getCacheKey, getCachePaths } from "./cache.js";
 import { corepackAssertYarnVersion, corepackEnableYarn } from "./corepack.js";
 import { setYarnVersion, yarnInstall } from "./yarn/index.js";
-import { getInputs } from "./inputs.js";
+import { getInputs, Inputs } from "./inputs.js";
 
 export async function main(): Promise<void> {
   core.info("Getting action inputs...");
-  const inputs = getInputs();
+  let inputs: Inputs;
+  try {
+    inputs = getInputs();
+  } catch (err) {
+    core.setFailed(`Failed to get action inputs: ${err.message}`);
+    return;
+  }
 
   core.info("Enabling Yarn...");
   try {


### PR DESCRIPTION
This pull request resolves #228 by adding a try-catch block when getting action inputs in the `main` function.