### PR TITLE
Only Lint Source Files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "root": true,
-  "ignorePatterns": ["dist"],
   "extends": ["eslint:recommended"],
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "ncc build src/index.ts",
     "format": "prettier --write --cache . !dist",
-    "lint": "eslint --ignore-path .gitignore .",
+    "lint": "eslint src",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request resolves #237 by modifying the `lint` command to only process source files in the `src` directory.