### PR TITLE
Don't Always Display Diff In Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Build Package
         run: |
           yarn build
-          git diff --exit-code --text HEAD
+          git diff --exit-code HEAD

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Check Format
         run: |
           yarn format
-          git diff --exit-code --text HEAD
+          git diff --exit-code HEAD
 
       - name: Check Lint
         run: yarn lint


### PR DESCRIPTION
This pull request resolves #320 by preventing the `build` and `check` workflows from always displaying diffs when checking for file changes.