### PR TITLE
Enable TypeScript Strict Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80386,8 +80386,8 @@ async function main() {
             return;
         }
     }
-    let cacheKey;
-    let cachePaths;
+    let cacheKey = "";
+    let cachePaths = [];
     if (inputs.cache) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Getting cache key");
         try {

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -60,7 +60,7 @@ describe("get cache key", () => {
     });
 
     jest.mocked(getYarnVersion).mockImplementation(async (options) => {
-      if (options.corepack) return "1.2.3";
+      if (options?.corepack) return "1.2.3";
       throw new Error("Unable to get Yarn version");
     });
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,8 +36,8 @@ export async function main(): Promise<void> {
     }
   }
 
-  let cacheKey: string;
-  let cachePaths: string[];
+  let cacheKey = "";
+  let cachePaths: string[] = [];
   if (inputs.cache) {
     core.startGroup("Getting cache key");
     try {

--- a/src/yarn/install.test.ts
+++ b/src/yarn/install.test.ts
@@ -80,9 +80,11 @@ it("should install package using Yarn", async () => {
   const { yarnInstall } = await import("./install.js");
 
   jest.mocked(exec).mockImplementation(async (commandLine, args, options) => {
-    options?.listeners?.stdline(
-      `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
-    );
+    if (options?.listeners?.stdline !== undefined) {
+      options?.listeners?.stdline(
+        `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
+      );
+    }
     return 0;
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,


### PR DESCRIPTION
This pull request resolves #356 by enabling TypeScript strict configuration and setting it to skip library checks. It also fixes typing errors related to the changes in the configuration.