### PR TITLE
Bump Copyright Year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Alfi Maulana
+Copyright (c) 2023-2025 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ To disable it, set the `cache` input parameter to `false` as shown below:
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
 
-Copyright © 2023-2024 [Alfi Maulana](https://github.com/threeal/)
+Copyright © 2023-2025 [Alfi Maulana](https://github.com/threeal/)


### PR DESCRIPTION
This pull request bumps the copyright year in both the `LICENSE` and `README.md` files of this project to 2025.