### PR TITLE
Specify Sample Package Version in Tests Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           repository: threeal/nodejs-starter
+          ref: v2.1.2
 
       - name: Checkout Action
         uses: actions/checkout@v4.2.2
@@ -102,6 +103,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           repository: threeal/nodejs-starter
+          ref: v2.1.2
 
       - name: Checkout Action
         uses: actions/checkout@v4.2.2
@@ -128,6 +130,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           repository: threeal/nodejs-starter
+          ref: v2.1.2
 
       - name: Checkout Action
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request resolves #546 by specifying the sample package version in the tests workflow to version 2.1.2.