### PR TITLE
Assert Using Yarn Berry

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1447,24 +1447,15 @@ async function main() {
     (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logInfo */ .fH)("Enabling Yarn...");
     try {
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackEnableYarn */ .e)();
+        if (inputs.version != "") {
+            await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_4__/* .setYarnVersion */ .DA)(inputs.version);
+        }
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackAssertYarnVersion */ .N)();
     }
     catch (err) {
         (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logError */ .vV)(`Failed to enable Yarn: ${(0,catched_error_message__WEBPACK_IMPORTED_MODULE_6__/* .getErrorMessage */ .u)(err)}`);
         process.exitCode = 1;
         return;
-    }
-    if (inputs.version != "") {
-        (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logInfo */ .fH)("Setting Yarn version...");
-        try {
-            await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_4__/* .setYarnVersion */ .DA)(inputs.version);
-            await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackAssertYarnVersion */ .N)();
-        }
-        catch (err) {
-            (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logError */ .vV)(`Failed to set Yarn version: ${(0,catched_error_message__WEBPACK_IMPORTED_MODULE_6__/* .getErrorMessage */ .u)(err)}`);
-            process.exitCode = 1;
-            return;
-        }
     }
     let cacheKey = { key: "", version: "" };
     if (inputs.cache) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1346,6 +1346,9 @@ __webpack_async_result__();
  */
 async function corepackAssertYarnVersion() {
     const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .getYarnVersion */ .$)();
+    if (version.match(/1\.\d+\.\d+/)) {
+        throw new Error(`This action does not support Yarn classic (${version})`);
+    }
     const corepackVersion = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .getYarnVersion */ .$)({ corepack: true });
     if (version !== corepackVersion) {
         throw new Error(`The \`yarn\` command is using a different version of Yarn, expected \`${corepackVersion}\` but got \`${version}\``);

--- a/src/corepack.test.ts
+++ b/src/corepack.test.ts
@@ -14,17 +14,25 @@ vi.mock("./yarn/index.js", () => ({ getYarnVersion: vi.fn() }));
 
 describe("assert Yarn version enabled by Corepack", () => {
   it("should not throw an error if Yarn versions are the same", async () => {
-    vi.mocked(getYarnVersion).mockResolvedValue("1.2.3");
+    vi.mocked(getYarnVersion).mockResolvedValue("2.3.4");
     await expect(corepackAssertYarnVersion()).resolves.toBeUndefined();
+  });
+
+  it("should throw an error if using Yarn classic", async () => {
+    vi.mocked(getYarnVersion).mockResolvedValue("1.2.3");
+
+    await expect(corepackAssertYarnVersion()).rejects.toThrow(
+      "This action does not support Yarn classic (1.2.3)",
+    );
   });
 
   it("should throw an error if Yarn versions are different", async () => {
     vi.mocked(getYarnVersion).mockImplementation(async (options) => {
-      return options?.corepack ? "1.2.3" : "1.2.4";
+      return options?.corepack ? "2.3.4" : "2.3.5";
     });
 
     await expect(corepackAssertYarnVersion()).rejects.toThrow(
-      "The `yarn` command is using a different version of Yarn, expected `1.2.3` but got `1.2.4`",
+      "The `yarn` command is using a different version of Yarn, expected `2.3.4` but got `2.3.5`",
     );
   });
 });

--- a/src/corepack.ts
+++ b/src/corepack.ts
@@ -16,6 +16,9 @@ import { getYarnVersion } from "./yarn/index.js";
  */
 export async function corepackAssertYarnVersion(): Promise<void> {
   const version = await getYarnVersion();
+  if (version.match(/1\.\d+\.\d+/)) {
+    throw new Error(`This action does not support Yarn classic (${version})`);
+  }
   const corepackVersion = await getYarnVersion({ corepack: true });
   if (version !== corepackVersion) {
     throw new Error(

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -288,8 +288,7 @@ describe("install Yarn dependencies", () => {
         "Getting action inputs...",
         "Enabling Yarn...",
         "Yarn enabled",
-        "Setting Yarn version...",
-        "Failed to set Yarn version: some error",
+        "Failed to enable Yarn: some error",
       ]);
     });
 
@@ -301,7 +300,6 @@ describe("install Yarn dependencies", () => {
         "Getting action inputs...",
         "Enabling Yarn...",
         "Yarn enabled",
-        "Setting Yarn version...",
         "Yarn version set to stable",
         "::group::Getting cache key",
         "::endgroup::",

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,23 +28,14 @@ export async function main(): Promise<void> {
   logInfo("Enabling Yarn...");
   try {
     await corepackEnableYarn();
+    if (inputs.version != "") {
+      await setYarnVersion(inputs.version);
+    }
     await corepackAssertYarnVersion();
   } catch (err) {
     logError(`Failed to enable Yarn: ${getErrorMessage(err)}`);
     process.exitCode = 1;
     return;
-  }
-
-  if (inputs.version != "") {
-    logInfo("Setting Yarn version...");
-    try {
-      await setYarnVersion(inputs.version);
-      await corepackAssertYarnVersion();
-    } catch (err) {
-      logError(`Failed to set Yarn version: ${getErrorMessage(err)}`);
-      process.exitCode = 1;
-      return;
-    }
   }
 
   let cacheKey = { key: "", version: "" };


### PR DESCRIPTION
This pull request resolves #548 by adding support for this action to assert whether Yarn Classic is being used, preventing it from using an unsupported Yarn version. In doing so, it also adjusts the flow for setting the Yarn version.