### PR TITLE
Extend TypeScript Configuration from Node.js Base Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
+    "@tsconfig/node23": "^23.0.1",
     "@types/node": "^22.13.10",
     "@vercel/ncc": "^0.38.3",
     "@vitest/coverage-v8": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@eslint/js':
         specifier: ^9.23.0
         version: 9.23.0
+      '@tsconfig/node23':
+        specifier: ^23.0.1
+        version: 23.0.1
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -261,10 +264,6 @@ packages:
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.22.0':
-    resolution: {integrity: sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/js@9.23.0':
     resolution: {integrity: sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -433,6 +432,9 @@ packages:
     resolution: {integrity: sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==}
     cpu: [x64]
     os: [win32]
+
+  '@tsconfig/node23@23.0.1':
+    resolution: {integrity: sha512-oJ0Y42TmsBLuLAfEbPTS5JXSbJJEEU4bULROS6zsL54Gdlw5aOy27rpsquotMKGf2auP6rkbfYsjl43WdGrNcg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1341,8 +1343,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.22.0': {}
-
   '@eslint/js@9.23.0': {}
 
   '@eslint/object-schema@2.1.6': {}
@@ -1464,6 +1464,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.35.0':
     optional: true
+
+  '@tsconfig/node23@23.0.1': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
+  "extends": "@tsconfig/node23",
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "strict": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "skipLibCheck": true
+    "module": "node16"
   }
 }


### PR DESCRIPTION
This pull request resolves #564 by extending `tsconfig.json` from [@tsconfig/node23](https://www.npmjs.com/package/@tsconfig/node23).