### PR TITLE
Integrate Lefthook

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,4 @@ jobs:
         run: pnpm install
 
       - name: Build Package
-        run: pnpm build
-
-      - name: Check Diff
-        run: git diff && git diff-index --quiet --exit-code HEAD
+        run: pnpm ncc build src/index.ts && git diff --exit-code dist

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,10 +19,10 @@ jobs:
         run: pnpm install
 
       - name: Check Format
-        run: pnpm format
+        run: pnpm prettier --check .
 
-      - name: Check Diff
-        run: git diff && git diff-index --quiet --exit-code HEAD
+      - name: Check Types
+        run: pnpm tsc --noEmit
 
       - name: Check Lint
-        run: pnpm lint
+        run: pnpm eslint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+dist
 pnpm-lock.yaml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,38 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: install dependencies
+      run: pnpm install
+      glob:
+        - .npmrc
+        - package.json
+        - pnpm-lock.yaml
+        - pnpm-workspace.yaml
+
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
+
+    - name: check types
+      run: pnpm tsc --noEmit
+      glob:
+        - "*.ts"
+        - .npmrc
+        - pnpm-lock.yaml
+        - tsconfig.json
+
+    - name: fix lint
+      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+
+    - name: build action
+      run: pnpm ncc build src/index.ts
+      glob:
+        - dist/*
+        - src/*.ts
+        - .npmrc
+        - pnpm-lock.yaml
+        - tsconfig.json
+      exclude:
+        - src/*.test.ts
+
+    - name: check diff
+      run: git diff --exit-code dist {staged_files}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "ncc build src/index.ts",
-    "format": "prettier --write --cache . !dist",
+    "format": "prettier --write --cache .",
     "lint": "eslint",
     "test": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "ncc build src/index.ts",
-    "format": "prettier --write --cache .",
-    "lint": "eslint",
     "test": "vitest run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@vercel/ncc": "^0.38.3",
     "@vitest/coverage-v8": "^3.0.8",
     "eslint": "^9.24.0",
+    "lefthook": "^1.11.14",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.29.0",
@@ -28,7 +29,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "lefthook"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       eslint:
         specifier: ^9.24.0
         version: 9.24.0
+      lefthook:
+        specifier: ^1.11.14
+        version: 1.11.14
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -862,6 +865,60 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@1.11.14:
+    resolution: {integrity: sha512-YPbUK6kGytY5W6aNUrzK7Vod3ynLVvj5JQiBh0DjlxCHMgIQPpFkDfwQzGw1E8CySyC95HXO83En5Ule8umS7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.11.14:
+    resolution: {integrity: sha512-l9RhSBp1SHqLCjSGWoeeVWqKcTBOMW8v2CCYrUt5eb6sik7AjT6+Neqf3sClsXH7SjELjj43yjmg6loqPtfDgg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.11.14:
+    resolution: {integrity: sha512-oSdJKGGMohktFXC6faZCUt5afyHpDwWGIWAkHGgOXUVD/LiZDEn6U/8cQmKm1UAfBySuPTtfir0VeM04y6188g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.11.14:
+    resolution: {integrity: sha512-gZdMWZwOtIhIPK3GPYac7JhXrxF188gkw65i6O7CedS/meDlK2vjBv5BUVLeD/satv4+jibEdV0h4Qqu/xIh2A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.11.14:
+    resolution: {integrity: sha512-sZmqbTsGQFQw7gbfi9eIHFOxfcs66QfZYLRMh1DktODhyhRXB8RtI6KMeKCtPEGLhbK55/I4TprC8Qvj86UBgw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.11.14:
+    resolution: {integrity: sha512-c+to1BRzFe419SNXAR6YpCBP8EVWxvUxlON3Z+efzmrHhdlhm7LvEoJcN4RQE4Gc2rJQJNe87OjsEZQkc4uQLg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.11.14:
+    resolution: {integrity: sha512-fivG3D9G4ASRCTf3ecfz1WdnrHCW9pezaI8v1NVve8t6B2q0d0yeaje5dfhoAsAvwiFPRaMzka1Qaoyu8O8G9Q==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.11.14:
+    resolution: {integrity: sha512-vikmG0jf7JVKR3be6Wk3l1jtEdedEqk1BTdsaHFX1bj0qk0azcqlZ819Wt/IoyIYDzQCHKowZ6DuXsRjT+RXWA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.11.14:
+    resolution: {integrity: sha512-5PoAJ9QKaqxJn1NWrhrhXpAROpl/dT7bGTo7VMj2ATO1cpRatbn6p+ssvc3tgeriFThowFb1D11Fg6OlFLi6UQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.11.14:
+    resolution: {integrity: sha512-kBeOPR0Aj5hQGxoBBntgz5/e/xaH5Vnzlq9lJjHW8sf23qu/JVUGg6ceCoicyVWJi+ZOBliTa8KzwCu+mgyJjw==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.11.14:
+    resolution: {integrity: sha512-Dv91Lnu/0jLT5pCZE0IkEfrpTXUhyX9WG4upEMPkKPCl5aBgJdoqVw/hbh8drcVrC6y7k1PqsRmWSERmO57weQ==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1964,6 +2021,49 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@1.11.14:
+    optional: true
+
+  lefthook-darwin-x64@1.11.14:
+    optional: true
+
+  lefthook-freebsd-arm64@1.11.14:
+    optional: true
+
+  lefthook-freebsd-x64@1.11.14:
+    optional: true
+
+  lefthook-linux-arm64@1.11.14:
+    optional: true
+
+  lefthook-linux-x64@1.11.14:
+    optional: true
+
+  lefthook-openbsd-arm64@1.11.14:
+    optional: true
+
+  lefthook-openbsd-x64@1.11.14:
+    optional: true
+
+  lefthook-windows-arm64@1.11.14:
+    optional: true
+
+  lefthook-windows-x64@1.11.14:
+    optional: true
+
+  lefthook@1.11.14:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.11.14
+      lefthook-darwin-x64: 1.11.14
+      lefthook-freebsd-arm64: 1.11.14
+      lefthook-freebsd-x64: 1.11.14
+      lefthook-linux-arm64: 1.11.14
+      lefthook-linux-x64: 1.11.14
+      lefthook-openbsd-arm64: 1.11.14
+      lefthook-openbsd-x64: 1.11.14
+      lefthook-windows-arm64: 1.11.14
+      lefthook-windows-x64: 1.11.14
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
This pull request resolves #619 by integrating [Lefthook](https://lefthook.dev/) into this project, allowing pre-commit hooks to be installed and executed on staged files. In doing so, this change also removes the `build`, `format`, and `lint` scripts as they are no longer necessary.