### PR TITLE
Configure TypeScript to Cover All Files

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm prettier --check .
 
       - name: Check Types
-        run: pnpm tsc --noEmit
+        run: pnpm tsc
 
       - name: Check Lint
         run: pnpm eslint

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,7 @@ pre-commit:
       run: pnpm prettier --write --ignore-unknown {staged_files}
 
     - name: check types
-      run: pnpm tsc --noEmit
+      run: pnpm tsc
       glob:
         - "*.ts"
         - .npmrc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "@tsconfig/node23",
-  "include": ["src"],
-  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "module": "node16"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node23",
   "compilerOptions": {
-    "module": "node16"
+    "module": "node16",
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #621 by modifying the TypeScript configuration to cover all files and not to emit compiled files.