### PR TITLE
Strict TypeScript ESLint Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1346,7 +1346,7 @@ __webpack_async_result__();
  */
 async function corepackAssertYarnVersion() {
     const version = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .getYarnVersion */ .$)();
-    if (version.match(/1\.\d+\.\d+/)) {
+    if (/1\.\d+\.\d+/.test(version)) {
         throw new Error(`This action does not support Yarn classic (${version})`);
     }
     const corepackVersion = await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .getYarnVersion */ .$)({ corepack: true });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
-  { ignores: ["dist"] },
-];
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,9 +10,7 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ["eslint.config.js"],
-        },
+        projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vercel/ncc": "^0.38.3",
     "@vitest/coverage-v8": "^3.0.8",
     "eslint": "^9.24.0",
+    "jiti": "^2.4.2",
     "lefthook": "^1.11.14",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,10 +38,13 @@ importers:
         version: 0.38.3
       '@vitest/coverage-v8':
         specifier: ^3.0.8
-        version: 3.0.8(vitest@3.0.8(@types/node@22.14.1))
+        version: 3.0.8(vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2))
       eslint:
         specifier: ^9.24.0
-        version: 9.24.0
+        version: 9.24.0(jiti@2.4.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       lefthook:
         specifier: ^1.11.14
         version: 1.11.14
@@ -53,10 +56,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.29.0
-        version: 8.29.0(eslint@9.24.0)(typescript@5.8.3)
+        version: 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.14.1)
+        version: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)
 
 packages:
 
@@ -854,6 +857,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1376,9 +1383,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.24.0)':
+  '@eslint-community/eslint-utils@4.5.1(eslint@9.24.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1551,15 +1558,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.29.0
-      '@typescript-eslint/type-utils': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.29.0
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -1568,14 +1575,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.29.0(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.29.0
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/typescript-estree': 8.29.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.29.0
       debug: 4.4.0
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1585,12 +1592,12 @@ snapshots:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
 
-  '@typescript-eslint/type-utils@8.29.0(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.29.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.0
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1612,13 +1619,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.29.0(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.29.0
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/typescript-estree': 8.29.0(typescript@5.8.3)
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1630,7 +1637,7 @@ snapshots:
 
   '@vercel/ncc@0.38.3': {}
 
-  '@vitest/coverage-v8@3.0.8(vitest@3.0.8(@types/node@22.14.1))':
+  '@vitest/coverage-v8@3.0.8(vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1644,7 +1651,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/node@22.14.1)
+      vitest: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1655,13 +1662,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.14.1))':
+  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.1(@types/node@22.14.1)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)
 
   '@vitest/pretty-format@3.0.8':
     dependencies:
@@ -1822,9 +1829,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.24.0:
+  eslint@9.24.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.1
@@ -1859,6 +1866,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2013,6 +2022,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jiti@2.4.2: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2284,12 +2295,12 @@ snapshots:
 
   type-fest@4.37.0: {}
 
-  typescript-eslint@8.29.0(eslint@9.24.0)(typescript@5.8.3):
+  typescript-eslint@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0)(typescript@5.8.3)
-      eslint: 9.24.0
+      '@typescript-eslint/eslint-plugin': 8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2302,13 +2313,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.0.8(@types/node@22.14.1):
+  vite-node@3.0.8(@types/node@22.14.1)(jiti@2.4.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@22.14.1)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2323,7 +2334,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.1(@types/node@22.14.1):
+  vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -2331,11 +2342,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
       fsevents: 2.3.3
+      jiti: 2.4.2
 
-  vitest@3.0.8(@types/node@22.14.1):
+  vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.14.1))
+      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -2351,8 +2363,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@22.14.1)
-      vite-node: 3.0.8(@types/node@22.14.1)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)
+      vite-node: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.1

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -39,20 +39,26 @@ beforeEach(() => {
 
 describe("get cache key", () => {
   beforeEach(() => {
-    vi.mocked(hashFile).mockImplementation((async (filePath) => {
-      if (filePath == "yarn.lock") return "b1484caea0bbcbfa9a3a32591e3cad5d";
-      throw new Error(`file not found: ${filePath}`);
-    }) as typeof hashFile);
+    vi.mocked(hashFile).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      (async (filePath) => {
+        if (filePath == "yarn.lock") return "b1484caea0bbcbfa9a3a32591e3cad5d";
+        throw new Error(`file not found: ${filePath}`);
+      }) as typeof hashFile,
+    );
 
     vi.mocked(fs.existsSync).mockImplementation((path) => {
       if (path == "yarn.lock") return true;
       return false;
     });
 
-    vi.mocked(getYarnVersion).mockImplementation(async (options) => {
-      if (options?.corepack) return "1.2.3";
-      throw new Error("Unable to get Yarn version");
-    });
+    vi.mocked(getYarnVersion).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (options) => {
+        if (options?.corepack) return "1.2.3";
+        throw new Error("Unable to get Yarn version");
+      },
+    );
   });
 
   it("should failed to get Yarn version", async () => {
@@ -122,23 +128,26 @@ describe("get cache paths", () => {
   beforeEach(() => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
-    vi.mocked(getYarnConfig).mockImplementation(async (name) => {
-      switch (name) {
-        case "cacheFolder":
-          return ".yarn/cache";
-        case "deferredVersionFolder":
-          return ".yarn/versions";
-        case "installStatePath":
-          return ".yarn/install-state.gz";
-        case "patchFolder":
-          return ".yarn/patches";
-        case "pnpUnpluggedFolder":
-          return ".yarn/unplugged";
-        case "virtualFolder":
-          return ".yarn/__virtual__";
-      }
-      throw new Error(`unknown config: ${name}`);
-    });
+    vi.mocked(getYarnConfig).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (name) => {
+        switch (name) {
+          case "cacheFolder":
+            return ".yarn/cache";
+          case "deferredVersionFolder":
+            return ".yarn/versions";
+          case "installStatePath":
+            return ".yarn/install-state.gz";
+          case "patchFolder":
+            return ".yarn/patches";
+          case "pnpUnpluggedFolder":
+            return ".yarn/unplugged";
+          case "virtualFolder":
+            return ".yarn/__virtual__";
+        }
+        throw new Error(`unknown config: ${name}`);
+      },
+    );
   });
 
   it("should failed to get Yarn config", async () => {

--- a/src/corepack.test.ts
+++ b/src/corepack.test.ts
@@ -27,9 +27,12 @@ describe("assert Yarn version enabled by Corepack", () => {
   });
 
   it("should throw an error if Yarn versions are different", async () => {
-    vi.mocked(getYarnVersion).mockImplementation(async (options) => {
-      return options?.corepack ? "2.3.4" : "2.3.5";
-    });
+    vi.mocked(getYarnVersion).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (options) => {
+        return options?.corepack ? "2.3.4" : "2.3.5";
+      },
+    );
 
     await expect(corepackAssertYarnVersion()).rejects.toThrow(
       "The `yarn` command is using a different version of Yarn, expected `2.3.4` but got `2.3.5`",

--- a/src/corepack.ts
+++ b/src/corepack.ts
@@ -16,7 +16,7 @@ import { getYarnVersion } from "./yarn/index.js";
  */
 export async function corepackAssertYarnVersion(): Promise<void> {
   const version = await getYarnVersion();
-  if (version.match(/1\.\d+\.\d+/)) {
+  if (/1\.\d+\.\d+/.test(version)) {
     throw new Error(`This action does not support Yarn classic (${version})`);
   }
   const corepackVersion = await getYarnVersion({ corepack: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { logError } from "gha-utils";
 import { main } from "./main.js";
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   logError(err);
   process.exit(1);
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -52,13 +52,19 @@ describe("install Yarn dependencies", () => {
     process.exitCode = 0;
     logs = [];
 
-    vi.mocked(restoreCache).mockImplementation(async (key, version) => {
-      return key == "some-key" && version == "some-version";
-    });
+    vi.mocked(restoreCache).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (key, version) => {
+        return key == "some-key" && version == "some-version";
+      },
+    );
 
-    vi.mocked(saveCache).mockImplementation(async (key, version) => {
-      return key == "some-key" && version == "some-version";
-    });
+    vi.mocked(saveCache).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (key, version) => {
+        return key == "some-key" && version == "some-version";
+      },
+    );
 
     vi.mocked(beginLogGroup).mockImplementation((name) => {
       logs.push(`::group::${name}`);
@@ -80,17 +86,26 @@ describe("install Yarn dependencies", () => {
       logs.push(message);
     });
 
-    vi.mocked(corepackEnableYarn).mockImplementation(async () => {
-      logInfo("Yarn enabled");
-    });
+    vi.mocked(corepackEnableYarn).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async () => {
+        logInfo("Yarn enabled");
+      },
+    );
 
-    vi.mocked(setYarnVersion).mockImplementation(async (version) => {
-      logInfo(`Yarn version set to ${version}`);
-    });
+    vi.mocked(setYarnVersion).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (version) => {
+        logInfo(`Yarn version set to ${version}`);
+      },
+    );
 
-    vi.mocked(yarnInstall).mockImplementation(async () => {
-      logInfo("Dependencies installed");
-    });
+    vi.mocked(yarnInstall).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async () => {
+        logInfo("Dependencies installed");
+      },
+    );
 
     vi.mocked(getCacheKey).mockResolvedValue({
       key: "unavailable-key",

--- a/src/yarn/config.ts
+++ b/src/yarn/config.ts
@@ -10,5 +10,5 @@ export async function getYarnConfig(name: string): Promise<string> {
   const res = await getExecOutput("yarn", ["config", name, "--json"], {
     silent: true,
   });
-  return JSON.parse(res.stdout).effective;
+  return (JSON.parse(res.stdout) as { effective: string }).effective;
 }

--- a/src/yarn/install.test.ts
+++ b/src/yarn/install.test.ts
@@ -69,14 +69,17 @@ describe("print Yarn install package output", () => {
 });
 
 it("should install package using Yarn", async () => {
-  vi.mocked(exec).mockImplementation(async (commandLine, args, options) => {
-    if (options?.listeners?.stdline !== undefined) {
-      options?.listeners?.stdline(
-        `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
-      );
-    }
-    return 0;
-  });
+  vi.mocked(exec).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async (commandLine, args, options) => {
+      if (options?.listeners?.stdline !== undefined) {
+        options.listeners.stdline(
+          `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
+        );
+      }
+      return 0;
+    },
+  );
 
   await yarnInstall();
 


### PR DESCRIPTION
This pull request resolves #623 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.