### PR TITLE
Add Missing `packages` Field in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 onlyBuiltDependencies:
   - esbuild
   - lefthook


### PR DESCRIPTION
This pull request resolves #634 by adding a missing `packages` field in the `pnpm-workspace.yaml` file.