### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1422,8 +1422,8 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var gha_utils__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(521);
 /* harmony import */ var _cache_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(619);
 /* harmony import */ var _corepack_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(355);
-/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(363);
-/* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(52);
+/* harmony import */ var _inputs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(52);
+/* harmony import */ var _yarn_index_js__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(363);
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_cache_js__WEBPACK_IMPORTED_MODULE_2__]);
 _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 
@@ -1437,7 +1437,7 @@ async function main() {
     (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logInfo */ .fH)("Getting action inputs...");
     let inputs;
     try {
-        inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_5__/* .getInputs */ .G)();
+        inputs = (0,_inputs_js__WEBPACK_IMPORTED_MODULE_4__/* .getInputs */ .G)();
     }
     catch (err) {
         (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .logError */ .vV)(`Failed to get action inputs: ${(0,catched_error_message__WEBPACK_IMPORTED_MODULE_6__/* .getErrorMessage */ .u)(err)}`);
@@ -1448,7 +1448,7 @@ async function main() {
     try {
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackEnableYarn */ .e)();
         if (inputs.version != "") {
-            await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_4__/* .setYarnVersion */ .DA)(inputs.version);
+            await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .setYarnVersion */ .DA)(inputs.version);
         }
         await (0,_corepack_js__WEBPACK_IMPORTED_MODULE_3__/* .corepackAssertYarnVersion */ .N)();
     }
@@ -1489,7 +1489,7 @@ async function main() {
     }
     (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .beginLogGroup */ .NL)("Installing dependencies");
     try {
-        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_4__/* .yarnInstall */ .yr)();
+        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_5__/* .yarnInstall */ .yr)();
     }
     catch (err) {
         (0,gha_utils__WEBPACK_IMPORTED_MODULE_1__/* .endLogGroup */ .NZ)();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jiti": "^2.5.1",
     "lefthook": "^1.12.2",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vitest": "^3.0.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1057,6 +1060,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2219,6 +2232,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
 
   prettier@3.6.2: {}
 

--- a/src/corepack.test.ts
+++ b/src/corepack.test.ts
@@ -1,8 +1,8 @@
 import { exec } from "@actions/exec";
 import { addPath } from "gha-utils";
 import { mkdirSync } from "node:fs";
-import path from "node:path";
 import { homedir } from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { corepackAssertYarnVersion, corepackEnableYarn } from "./corepack.js";
 import { getYarnVersion } from "./yarn/index.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ import {
 
 import { getCacheKey, getCachePaths } from "./cache.js";
 import { corepackAssertYarnVersion, corepackEnableYarn } from "./corepack.js";
-import { setYarnVersion, yarnInstall } from "./yarn/index.js";
 import { getInputs, Inputs } from "./inputs.js";
+import { setYarnVersion, yarnInstall } from "./yarn/index.js";
 
 export async function main(): Promise<void> {
   logInfo("Getting action inputs...");


### PR DESCRIPTION
This pull request resolves #665 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.