### PR TITLE
Fix outdated conventions in ESLint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,17 +1,16 @@
-import eslint from "@eslint/js";
+import js from "@eslint/js";
 import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig(
   globalIgnores(["dist"]),
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
       },
     },
   },


### PR DESCRIPTION
This pull request resolves #832 by making the following changes:

* Renaming the `@eslint/js` import alias from `eslint` to `js`.
* Removing the redundant `tsconfigRootDir` option from `parserOptions`.
